### PR TITLE
Use str_copy instead of strdup

### DIFF
--- a/src/clib-search.c
+++ b/src/clib-search.c
@@ -16,6 +16,7 @@
 #include "http-get/http-get.h"
 #include "wiki-registry/wiki-registry.h"
 #include "clib-package/clib-package.h"
+#include "str-copy/str-copy.h"
 #include "version.h"
 
 #define CLIB_WIKI_URL "https://github.com/clibs/clib/wiki/Packages"
@@ -37,7 +38,7 @@ matches(int count, char *args[], wiki_package_t *pkg) {
     if (strstr(name, args[i])) return 1;
   }
 
-  description = strdup(pkg->description);
+  description = str_copy(pkg->description);
   if (NULL == description) goto fail;
   case_lower(description);
   for (int i = 0; i < count; i++) {
@@ -69,7 +70,7 @@ set_cache:;
   http_get_response_t *res = http_get(CLIB_WIKI_URL);
   if (!res->ok) return NULL;
 
-  char *html = strdup(res->data);
+  char *html = str_copy(res->data);
   http_get_free(res);
 
   if (NULL == html) return html;

--- a/src/clib.c
+++ b/src/clib.c
@@ -12,6 +12,7 @@
 #include "trim/trim.h"
 #include "which/which.h"
 #include "str-flatten/str-flatten.h"
+#include "str-copy/str-copy.h"
 #include "version.h"
 
 static const char *usage =
@@ -49,7 +50,7 @@ main(int argc, char **argv) {
     return 1;
   }
 
-  char *cmd = strdup(argv[1]);
+  char *cmd = str_copy(argv[1]);
   if (NULL == cmd) {
     fprintf(stderr, "Memory allocation failure\n");
     return 1;


### PR DESCRIPTION
Since strdup is not standardized in ANSI C, using str_copy is better.

Currently, strdup is also used in `deps`. So I'll create PR to each project.
