### PR TITLE
Fix 'cmd' leak in help command

### DIFF
--- a/src/clib.c
+++ b/src/clib.c
@@ -66,6 +66,7 @@ main(int argc, const char **argv) {
 
   if (0 == strcmp(cmd, "help")) {
     if (argc >= 3) {
+      free(cmd);
       cmd = str_copy(argv[2]);
       args = str_copy("--help");
     } else {


### PR DESCRIPTION
Fixed simple `cmd` leak :)
## Before:

```
$ valgrind --leak-check=full ./clib help install > /dev/null
==24755== Memcheck, a memory error detector
==24755== Copyright (C) 2002-2011, and GNU GPL'd, by Julian Seward et al.
==24755== Using Valgrind-3.7.0 and LibVEX; rerun with -h for copyright info
==24755== Command: ./clib help install
==24755== 
==24755== 
==24755== HEAP SUMMARY:
==24755==     in use at exit: 5 bytes in 1 blocks
==24755==   total heap usage: 8 allocs, 7 frees, 1,223 bytes allocated
==24755== 
==24755== 5 bytes in 1 blocks are definitely lost in loss record 1 of 1
==24755==    at 0x4C2B6CD: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==24755==    by 0x41CBB1: str_copy (in /home/stephen/clib/clib)
==24755==    by 0x401B09: main (in /home/stephen/clib/clib)
==24755== 
==24755== LEAK SUMMARY:
==24755==    definitely lost: 5 bytes in 1 blocks
==24755==    indirectly lost: 0 bytes in 0 blocks
==24755==      possibly lost: 0 bytes in 0 blocks
==24755==    still reachable: 0 bytes in 0 blocks
==24755==         suppressed: 0 bytes in 0 blocks
==24755== 
==24755== For counts of detected and suppressed errors, rerun with: -v
==24755== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 2 from 2)
```
## After:

```
$ valgrind --leak-check=full ./clib help install > /dev/null
==24922== Memcheck, a memory error detector
==24922== Copyright (C) 2002-2011, and GNU GPL'd, by Julian Seward et al.
==24922== Using Valgrind-3.7.0 and LibVEX; rerun with -h for copyright info
==24922== Command: ./clib help install
==24922== 
==24922== 
==24922== HEAP SUMMARY:
==24922==     in use at exit: 0 bytes in 0 blocks
==24922==   total heap usage: 8 allocs, 8 frees, 1,223 bytes allocated
==24922== 
==24922== All heap blocks were freed -- no leaks are possible
==24922== 
==24922== For counts of detected and suppressed errors, rerun with: -v
==24922== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 2 from 2)
```
