### PR TITLE
search: Fix 'name' leak

### DIFF
--- a/src/clib-search.c
+++ b/src/clib-search.c
@@ -36,7 +36,10 @@ matches(int count, char *args[], wiki_package_t *pkg) {
   if (NULL == name) goto fail;
   case_lower(name);
   for (int i = 0; i < count; i++) {
-    if (strstr(name, args[i])) return 1;
+    if (strstr(name, args[i])) {
+      free(name);
+      return 1;
+    }
   }
 
   description = str_copy(pkg->description);
@@ -45,11 +48,13 @@ matches(int count, char *args[], wiki_package_t *pkg) {
   for (int i = 0; i < count; i++) {
     if (strstr(description, args[i])) {
       free(description);
+      free(name);
       return 1;
     }
   }
 
 fail:
+  if (name) free(name);
   if (description) free(description);
   return 0;
 }


### PR DESCRIPTION
In an earlier version, the result of `clib_package_parse_name` didn't need to be freed.
## Before

$ valgrind --leak-check=full ./clib-search str foo > /dev/null
==25106== Memcheck, a memory error detector
==25106== Copyright (C) 2002-2011, and GNU GPL'd, by Julian Seward et al.
==25106== Using Valgrind-3.7.0 and LibVEX; rerun with -h for copyright info
==25106== Command: ./clib-search str foo
==25106== 
==25106== 
==25106== HEAP SUMMARY:
==25106==     in use at exit: 573 bytes in 64 blocks
==25106==   total heap usage: 13,620 allocs, 13,556 frees, 1,658,352 bytes allocated
==25106== 
==25106== 573 bytes in 64 blocks are definitely lost in loss record 1 of 1
==25106==    at 0x4C2B6CD: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==25106==    by 0x41CC4D: str_copy (in /home/stephen/clib/clib-search)
==25106==    by 0x41A9D9: parse_repo_name (in /home/stephen/clib/clib-search)
==25106==    by 0x4031D1: clib_package_parse_name (in /home/stephen/clib/clib-search)
==25106==    by 0x401995: matches (in /home/stephen/clib/clib-search)
==25106==    by 0x401CB3: main (in /home/stephen/clib/clib-search)
==25106== 
==25106== LEAK SUMMARY:
==25106==    definitely lost: 573 bytes in 64 blocks
==25106==    indirectly lost: 0 bytes in 0 blocks
==25106==      possibly lost: 0 bytes in 0 blocks
==25106==    still reachable: 0 bytes in 0 blocks
==25106==         suppressed: 0 bytes in 0 blocks
==25106== 
==25106== For counts of detected and suppressed errors, rerun with: -v
==25106== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 2 from 2)
## After

$ valgrind --leak-check=full ./clib-search str foo > /dev/null
==25272== Memcheck, a memory error detector
==25272== Copyright (C) 2002-2011, and GNU GPL'd, by Julian Seward et al.
==25272== Using Valgrind-3.7.0 and LibVEX; rerun with -h for copyright info
==25272== Command: ./clib-search str foo
==25272== 
==25272== 
==25272== HEAP SUMMARY:
==25272==     in use at exit: 0 bytes in 0 blocks
==25272==   total heap usage: 13,620 allocs, 13,620 frees, 1,658,352 bytes allocated
==25272== 
==25272== All heap blocks were freed -- no leaks are possible
==25272== 
==25272== For counts of detected and suppressed errors, rerun with: -v
==25272== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 2 from 2)
