### PR TITLE
Unifies copyright statement across project

### DIFF
--- a/src/clib-install.c
+++ b/src/clib-install.c
@@ -2,7 +2,7 @@
 //
 // clib-install.c
 //
-// Copyright (c) 2013 Stephen Mathieson
+// Copyright (c) 2012-2014 clib authors
 // MIT licensed
 //
 

--- a/src/clib-search.c
+++ b/src/clib-search.c
@@ -2,7 +2,7 @@
 //
 // clib-search.c
 //
-// Copyright (c) 2014 Stephen Mathieson
+// Copyright (c) 2012-2014 clib authors
 // MIT licensed
 //
 

--- a/src/clib.c
+++ b/src/clib.c
@@ -2,7 +2,7 @@
 //
 // clib.c
 //
-// Copyright (c) 2013 Stephen Mathieson
+// Copyright (c) 2012-2014 clib authors
 // MIT licensed
 //
 

--- a/src/version.h
+++ b/src/version.h
@@ -2,7 +2,7 @@
 //
 // version.h
 //
-// Copyright (c) 2013 Stephen Mathieson
+// Copyright (c) 2012-2014 clib authors
 // MIT licensed
 //
 


### PR DESCRIPTION
According to commit [a0368e7](https://github.com/clibs/clib/commit/a0368e730bda632a86e55b4e8873146baaad49ba), the project is copyright to `clib authors` - but in the files, it is copyright to @stephenmathieson. This pull request rights the various files in `src` to show the correct copyright statement, fixing the license.
