### PR TITLE
fix travis build error with libcurl4-guntls-dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: c
-before_install: sudo apt-get install libcurl4-gnutls-dev -qq
+before_install: 
+- sudo apt-get update
+- sudo apt-get install -qq libcurl4-gnutls-dev
 install: sudo make install
 script: sudo make test


### PR DESCRIPTION
inspired by https://github.com/jupyter/nbviewer/blob/master/.travis.yml
this repo is [passed](https://travis-ci.org/jupyter/nbviewer) in recent build, so i'm guessing `sudo apt-get update` will fix this issue but still unsure, please correct me :cherries: 

/cc @stephenmathieson 
