### PR TITLE
Move wiki/Packages list to dedicated repo

### DIFF
--- a/src/clib-search.c
+++ b/src/clib-search.c
@@ -24,7 +24,7 @@
 #include "debug/debug.h"
 #include "version.h"
 
-#define CLIB_WIKI_URL "https://github.com/clibs/clib/wiki/Packages"
+#define CLIB_PACKAGES_URL "https://raw.githubusercontent.com/warmwaffles/clib-packages/master/Packages.md"
 #define CLIB_SEARCH_CACHE "clib-search.cache"
 #define CLIB_SEARCH_CACHE_TIME 1000 * 60 * 60 * 5
 
@@ -118,8 +118,8 @@ wiki_html_cache() {
   }
 
 set_cache:;
-  debug(&debugger, "setting cache (%s) from %s", cache_file, CLIB_WIKI_URL);
-  http_get_response_t *res = http_get(CLIB_WIKI_URL);
+  debug(&debugger, "setting cache (%s) from %s", cache_file, CLIB_PACKAGES_URL);
+  http_get_response_t *res = http_get(CLIB_PACKAGES_URL);
   if (!res->ok) return NULL;
 
   char *html = strdup(res->data);


### PR DESCRIPTION
The wiki _could_ be modified by anyone and could cause confusion. To avoid this, I propose we move the packages to a dedicated repository that takes PRs to ensure accuracy.

This is by no means the way we should do it, but more so I am looking for validation of this idea.

The other thought I had was that the `Packages` document could live on the official clib repo, but I think that may be too much noise on the main repo.

Thoughts?