### PR TITLE
Add cygwin compatible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,13 @@
 CC     ?= cc
 PREFIX ?= /usr/local
 
-ifeq ($(OS),Windows_NT)
+ifeq ($(shell uname -o),Cygwin)
+BINS    = clib.exe clib-install.exe clib-search.exe
+LDFLAGS = -lcurl
+CP      = cp -f
+RM      = rm -f
+MKDIR_P = mkdir -p
+else ifeq ($(OS),Windows_NT)
 BINS    = clib.exe clib-install.exe clib-search.exe
 LDFLAGS = -lcurldll
 CP      = copy /Y

--- a/test.sh
+++ b/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-TESTS=`find test/* -type f -perm +111`
+TESTS=`find test/* -type f -perm -111`
 EXIT_CODE=0
 
 echo -e "\nRunning clib(1) tests\n"


### PR DESCRIPTION
cygwin do not use 
```
LDFLAGS = -lcurldll
CP      = copy /Y
RM      = del /Q /S
MKDIR_P = mkdir
```
and do not use
```
BINS    = clib clib-install clib-search
```
but use 
```
BINS    = clib.exe clib-install.exe clib-search.exe
LDFLAGS = -lcurl
CP      = cp -f
RM      = rm -f
MKDIR_P = mkdir -p
```

and i use `ifeq ($(shell uname -o),Cygwin)` to identify it.