### PR TITLE
Add 'curl-config' to Makefile to find cURL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-
 CC     ?= cc
 BINS    = clib clib-install clib-search
 CP      = cp -f

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ SRC  = $(wildcard src/*.c)
 DEPS = $(wildcard deps/*/*.c)
 OBJS = $(DEPS:.c=.o)
 
-CFLAGS  = -std=c99 -Ideps -Wall -Wno-unused-function -U__STRICT_ANSI__
+CFLAGS  = -std=c99 -Ideps -Wall -Wno-unused-function -U__STRICT_ANSI__ $(shell curl-config --cflags) $(shell curl-config --libs)
 
 all: $(BINS)
 

--- a/Makefile
+++ b/Makefile
@@ -1,32 +1,16 @@
 
 CC     ?= cc
-PREFIX ?= /usr/local
-
-ifeq ($(shell uname -o),Cygwin)
-BINS    = clib.exe clib-install.exe clib-search.exe
-LDFLAGS = -lcurl
-CP      = cp -f
-RM      = rm -f
-MKDIR_P = mkdir -p
-else ifeq ($(OS),Windows_NT)
-BINS    = clib.exe clib-install.exe clib-search.exe
-LDFLAGS = -lcurldll
-CP      = copy /Y
-RM      = del /Q /S
-MKDIR_P = mkdir
-else
 BINS    = clib clib-install clib-search
-LDFLAGS = -lcurl
 CP      = cp -f
 RM      = rm -f
 MKDIR_P = mkdir -p
-endif
 
 SRC  = $(wildcard src/*.c)
 DEPS = $(wildcard deps/*/*.c)
 OBJS = $(DEPS:.c=.o)
 
-CFLAGS  = -std=c99 -Ideps -Wall -Wno-unused-function -U__STRICT_ANSI__ $(shell curl-config --cflags) $(shell curl-config --libs)
+CFLAGS  = -std=c99 -Ideps -Wall -Wno-unused-function -U__STRICT_ANSI__ $(shell curl-config --cflags)
+LDFLAGS = $(shell curl-config --libs)
 
 all: $(BINS)
 


### PR DESCRIPTION
I needed this change to get clib to compile under FreeBSD, where I had installed libcurl via pkgng. I'm not sure as I haven't tested on other platforms yet but apparently this was added in curl 7.7.2 (http://curl.haxx.se/libcurl/using/) and should be available with most libcurl installations.

Perhaps there's a better way to do this if it is desired to support older versions of libcurl?