### PR TITLE
Pre-compiled Windows binaries for future Github releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,44 @@
 language: c
-before_install: 
-- sudo apt-get update
-- sudo apt-get install -qq libcurl4-gnutls-dev
-install: sudo make install
-script: sudo make test
+services:
+  - docker
+jobs:
+  include:
+    - stage: test
+      env: job=test
+      before_install:
+        - sudo apt-get update
+        - sudo apt-get install -qq libcurl4-gnutls-dev
+      install: sudo make install
+      script: sudo make test
+    - stage: test
+      env: job=dockcross-windows-x64
+      before_install:
+        - echo "Installing cross-compiling environment (for Windows x64)"
+        - echo "$PWD"
+        - mkdir -p dockcross
+        - sudo docker run --rm dockcross/windows-x64 > ./dockcross/dockcross-windows-x64
+        - chmod +x ./dockcross/dockcross-windows-x64
+        - PATH="$PATH:$PWD/dockcross"
+        - echo "Compiling libcurl"
+        - wget https://curl.haxx.se/download/curl-7.54.0.tar.gz
+        - tar xzf curl-*
+        - CURL_SRC=curl-*
+        - echo "$CURL_SRC"
+        - echo 'We cannot cd and then run dockcross, because docker mounts the working dir'
+        - echo 'and curl-config will later report the absolute path used during ./configure'
+        - dockcross-windows-x64 bash -c 'cd '"$CURL_SRC"' && ./configure --prefix="/work/deps/curl" --host=x86_64-w64-mingw32.static --with-winssl --disable-dependency-tracking'
+        - dockcross-windows-x64 bash -c 'cd '"$CURL_SRC"' && make'
+        - dockcross-windows-x64 bash -c 'cd '"$CURL_SRC"' && make install'
+        - ls deps/curl/bin
+        - ls deps/curl/share
+        - ls deps/curl/include
+        - ls deps/curl/lib
+      install:
+        - deps/curl/bin/curl-config --cflags
+        - deps/curl/bin/curl-config --static-libs
+        - deps/curl/bin/curl-config --libs
+        - dockcross-windows-x64 make STATIC=true EXE=true
+        - ls
+        - echo 'TODO upload artifacts'
+      script:
+        - echo 'It works, trust me'

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,11 @@
 CC     ?= cc
 PREFIX ?= /usr/local
 
-BINS    = clib clib-install clib-search
+ifdef EXE
+	BINS = clib.exe clib-install.exe clib-search.exe
+else
+	BINS = clib clib-install clib-search
+endif
 CP      = cp -f
 RM      = rm -f
 MKDIR   = mkdir -p
@@ -10,8 +14,13 @@ SRC  = $(wildcard src/*.c)
 DEPS = $(wildcard deps/*/*.c)
 OBJS = $(DEPS:.c=.o)
 
-CFLAGS  = -std=c99 -Ideps -Wall -Wno-unused-function -U__STRICT_ANSI__ $(shell curl-config --cflags)
-LDFLAGS = $(shell curl-config --libs)
+ifdef STATIC
+	CFLAGS  = -DCURL_STATICLIB -std=c99 -Ideps -Wall -Wno-unused-function -U__STRICT_ANSI__ $(shell deps/curl/bin/curl-config --cflags)
+	LDFLAGS =  -static $(shell deps/curl/bin/curl-config --static-libs)
+else
+	CFLAGS  = -std=c99 -Ideps -Wall -Wno-unused-function -U__STRICT_ANSI__ $(shell curl-config --cflags)
+	LDFLAGS = $(shell curl-config --libs)
+endif
 
 all: $(BINS)
 

--- a/test.sh
+++ b/test.sh
@@ -2,6 +2,7 @@
 
 TESTS=`find test/* -type f -perm -111`
 EXIT_CODE=0
+export PATH="$PWD:$PATH"
 
 echo -e "\nRunning clib(1) tests\n"
 


### PR DESCRIPTION
It only took 32 tries, but I'm confident it'll build now! This PR is to open discussion about using [GitHub Releases Uploading](https://docs.travis-ci.com/user/deployment/releases/) to attach pre-compiled Windows binaries to future Github releases. I've got the compiling bit done. Specifically, a statically linked `clib` with libcurl.

Travis Build: https://travis-ci.org/wmhilton-contrib/clib/builds