### PR TITLE
Portability: make shell scripts POSIX sh compatible

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -12,13 +12,13 @@
 
   With [homebrew](https://github.com/Homebrew/homebrew):
 
-```bash
+```sh
 $ brew install clib
 ```
 
   With git:
 
-```bash
+```sh
 $ git clone https://github.com/clibs/clib.git /tmp/clib
 $ cd /tmp/clib
 $ make install
@@ -26,7 +26,7 @@ $ make install
 
   Ubuntu:
 
-```bash  
+```sh  
 # install libcurl
 $ sudo apt-get install libcurl4-gnutls-dev -qq
 # clone
@@ -70,25 +70,25 @@ $ sudo make install
 
  Install a few dependencies to `./deps`:
 
-```bash
+```sh
 $ clib install clibs/ms clibs/commander
 ```
 
  Install them to `./src` instead:
 
-```bash
+```sh
 $ clib install clibs/ms clibs/commander -o src
 ```
 
  When installing libraries from the `clibs` org you can omit the name:
 
-```bash
+```sh
 $ clib install ms file hash
 ```
 
  Install some executables:
 
-```bash
+```sh
 $ clib install visionmedia/mon visionmedia/every visionmedia/watch
 ```
 

--- a/scripts/convert_all_ccan2clib.sh
+++ b/scripts/convert_all_ccan2clib.sh
@@ -1,18 +1,18 @@
-#!/bin/bash
+#!/bin/sh
 
 git clone https://github.com/rustyrussell/ccan
 
 # Output directory
 mkdir clibs
 
-cd ccan
+cd ccan || exit
 
 make
 make tools
 
 # Convert ccan modules into Clib repos
-for file in $(ls ccan); do
-	if [[ -d ccan/$file ]]; then
-		python ../ccan2clib.py $file ../clibs
+for file in ccan/*; do
+	if [ -d "$file" ]; then
+		python ../ccan2clib.py "${file#ccan/}" ../clibs
 	fi
 done

--- a/test.sh
+++ b/test.sh
@@ -1,14 +1,13 @@
-#!/bin/bash
+#!/bin/sh
 
-TESTS=`find test/* -type f -perm -111`
+TESTS=$(find test/* -type f -perm -111)
 EXIT_CODE=0
 export PATH="$PWD:$PATH"
 
-echo -e "\nRunning clib(1) tests\n"
+printf "\nRunning clib(1) tests\n\n"
 
 for t in $TESTS; do
-  ./$t
-  if [ $? -ne 0 ]; then
+  if ! ./"$t"; then
     echo >&2 "  (✖) $t"
     EXIT_CODE=1
   else

--- a/test/gh-35-exit-codes.sh
+++ b/test/gh-35-exit-codes.sh
@@ -1,9 +1,9 @@
-#!/bin/bash
+#!/bin/sh
 
 # see #35
 
-clib install stephenmathieson/rot132.c > /dev/null 2>&1
-[ $? -ne 0 ] || {
-  echo >&2 "Failed installations should exit with a non-zero exit code";
+clib install stephenmathieson/rot132.c > /dev/null 2>&1 && {
+  echo >&2 "Failed installations should exit with a non-zero exit code"
   exit 1
 }
+exit 0

--- a/test/help.sh
+++ b/test/help.sh
@@ -1,23 +1,23 @@
-#!/bin/bash
+#!/bin/sh
 
 clib help 2> /dev/null
 [ $? -eq 1 ] || {
-  echo >&2 "Expected \`clib help\` to fail";
+  echo >&2 "Expected \`clib help\` to fail"
   exit 1
 }
 
-ACTUAL=`clib help install`
-EXPECTED=`clib install --help`
+ACTUAL=$(clib help install)
+EXPECTED=$(clib install --help)
 
-[ "$ACTUAL" == "$EXPECTED" ] || {
+[ "$ACTUAL" = "$EXPECTED" ] || {
   echo >&2 "\`help install\` should ouput clib-install --help"
   exit 1
 }
 
-ACTUAL=`clib help search`
-EXPECTED=`clib search --help`
+ACTUAL=$(clib help search)
+EXPECTED=$(clib search --help)
 
-[ "$ACTUAL" == "$EXPECTED" ] || {
+[ "$ACTUAL" = "$EXPECTED" ] || {
   echo >&2 "\`help search\` should ouput clib-search --help"
   exit 1
 }

--- a/test/install-binary-dependencies.sh
+++ b/test/install-binary-dependencies.sh
@@ -1,11 +1,10 @@
-#!/bin/bash
+#!/bin/sh
 
-clib install stephenmathieson/tabs-to-spaces@1.0.0 > /dev/null
-[ $? -eq 0 ] || {
-  echo >&2 "Failed to install stephenmathieson/tabs-to-spaces";
+clib install stephenmathieson/tabs-to-spaces@1.0.0 > /dev/null || {
+  echo >&2 "Failed to install stephenmathieson/tabs-to-spaces"
   exit 1
 }
 command -v t2s >/dev/null 2>&1 || {
-  echo >&2 "Failed to put t2s on path";
+  echo >&2 "Failed to put t2s on path"
   exit 1
 }

--- a/test/install-brace-expansion.sh
+++ b/test/install-brace-expansion.sh
@@ -1,12 +1,12 @@
-#!/bin/bash
+#!/bin/sh
 
 throw() {
-  echo >&2 $1
+  echo >&2 "$1"
   exit 1
 }
 
-clib install -o tmp stephenmathieson/{trim,case}.c > /dev/null
-[ $? -eq 0 ] || throw "expecting successful exit code"
+clib install -o tmp stephenmathieson/trim.c stephenmathieson/case.c > /dev/null ||
+  throw "expecting successful exit code"
 
 [ -d ./tmp/case ] && [ -f ./tmp/case/package.json ] ||
   throw "failed to install case.c"

--- a/test/install-deps-from-package-json.sh
+++ b/test/install-deps-from-package-json.sh
@@ -1,13 +1,13 @@
-#!/bin/bash
+#!/bin/sh
 
 throw() {
-  echo >&2 $1
+  echo >&2 "$1"
   exit 1
 }
 
 rm -rf tmp
 mkdir -p tmp
-cd tmp
+cd tmp || exit
 
 # see https://github.com/clibs/clib/issues/45
 cat > package.json << EOF
@@ -24,5 +24,5 @@ clib install > /dev/null 2>&1
 
 [ $? -eq 1 ] || throw "expecting exit code of 1";
 
-cd - > /dev/null
+cd - > /dev/null || exit
 rm -rf ./tmp

--- a/test/install-multiple-clibs-libs.sh
+++ b/test/install-multiple-clibs-libs.sh
@@ -1,12 +1,12 @@
-#!/bin/bash
+#!/bin/sh
 
 throw() {
-  echo >&2 $1
+  echo >&2 "$1"
   exit 1
 }
 
-clib install -o tmp ms file hash > /dev/null
-[ $? -eq 0 ] || throw "expecting successful exit code"
+clib install -o tmp ms file hash > /dev/null ||
+  throw "expecting successful exit code"
 
 [ -d ./tmp/ms ] && [ -f ./tmp/ms/package.json ] ||
   throw "failed to install ms"

--- a/test/install-multiple-libs.sh
+++ b/test/install-multiple-libs.sh
@@ -1,13 +1,13 @@
-#!/bin/bash
+#!/bin/sh
 
 throw() {
-  echo >&2 $1
+  echo >&2 "$1"
   exit 1
 }
 
 clib install -o tmp \
-  stephenmathieson/case.c stephenmathieson/trim.c > /dev/null
-[ $? -eq 0 ] || throw "expecting successful exit code"
+  stephenmathieson/case.c stephenmathieson/trim.c > /dev/null ||
+  throw "expecting successful exit code"
 
 [ -d ./tmp/case ] && [ -f ./tmp/case/package.json ] ||
   throw "failed to install case.c"

--- a/test/install-save.sh
+++ b/test/install-save.sh
@@ -1,13 +1,13 @@
-#!/bin/bash
+#!/bin/sh
 mkdir -p tmp/test-save
 cp test/data/test-save-package.json tmp/test-save/package.json
 
-pushd tmp/test-save
+cd tmp/test-save || exit
 ../../clib-install --save stephenmathieson/tabs-to-spaces@1.0.0 >/dev/null
 ../../clib-install -S darthtrevino/str-concat@0.0.2 >/dev/null
 ../../clib-install --save-dev jwerle/fs.c@0.1.1 >/dev/null
 ../../clib-install -D clibs/parson@1.0.2 >/dev/null
-popd
+cd - || exit
 
 if ! grep --quiet "stephenmathieson/tabs-to-spaces" tmp/test-save/package.json; then
   echo >&2 "Failed to find stephenmathieson/tabs-to-spaces saved in package.json"

--- a/test/search-basic.sh
+++ b/test/search-basic.sh
@@ -1,17 +1,22 @@
-#!/bin/bash
+#!/bin/sh
 
 CACHE=$TMPDIR/clib-search.cache
-rm -f $CACHE 2> /dev/null
+rm -f "$CACHE" 2> /dev/null
 
-N=`clib search | wc -l`
+N=$(clib search | wc -l)
 # lame check for more than 100 lines of output
-[ $N -lt 100 ] && {
-  echo >&2 "Expected \`clib search\` to return at least 100 results";
+[ "$N" -lt 100 ] && {
+  echo >&2 "Expected \`clib search\` to return at least 100 results"
   exit 1
 }
 
-TRIM=`clib search trim`
-[[ "$TRIM" == *"stephenmathieson/trim.c"* ]] || {
-  echo >&2 "Expected \`clib search trim\` to output stephenmathieson/trim.c";
-  exit 1
-}
+TRIM=$(clib search trim)
+case "$TRIM" in
+  *"stephenmathieson/trim.c"*)
+    :
+    ;;
+  *)
+    echo >&2 "Expected \`clib search trim\` to output stephenmathieson/trim.c"
+    exit 1
+    ;;
+esac

--- a/test/search-no-color.sh
+++ b/test/search-no-color.sh
@@ -1,14 +1,15 @@
-#!/bin/bash
+#!/bin/sh
 
 color_tests() {
-  local opt="$1"
-  local cmd="./clib-search ${opt}"
-  local stdout=`${cmd}`
+  cmd="./clib-search $1"
+  stdout=$($cmd)
   # lame check for color
-  if [[ $stdout == *"[39;49;90;49"* ]]; then
-    echo >&2 "Expected \`${cmd}\` to surpress all color";
-    exit 1
-  fi
+  case "$stdout" in
+    *"[39;49;90;49"*)
+      echo >&2 "Expected \`${cmd}\` to suppress all color"
+      exit 1
+      ;;
+  esac
 }
 
 color_tests --no-color


### PR DESCRIPTION
No functional changes. The goal of this patch is to remove the
dependency on bash and instead be compatible to POSIX sh, to be
installed on prisitine Unix like systems (*BSD, minix, alpineLinux, etc).
[shellcheck](http://shellcheck.net) was used to lint shell scripts.

- Use `#!/bin/sh` in place of `#!/bin/bash`
- fix non portable shell syntax
- slight syntax improvements as reported by `shellcheck -s sh` linter