### PR TITLE
fixed: mention init in clib's help.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -61,6 +61,7 @@ $ sudo make install
 
   Commands:
 
+    init               Start a new project.
     install [name...]  Install one or more packages
     search [query]     Search for packages
     help <cmd>         Display help for cmd

--- a/src/clib.c
+++ b/src/clib.c
@@ -30,6 +30,7 @@ static const char *usage =
   "\n"
   "  Commands:\n"
   "\n"
+  "    init               Start a new project\n"
   "    install [name...]  Install one or more packages\n"
   "    search [query]     Search for packages\n"
   "    help <cmd>         Display help for cmd\n"


### PR DESCRIPTION
Mention init command in clib's help.