### PR TITLE
Makefile: fix 45 missing prerequisites reported by Vemake

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,12 +40,16 @@ all: $(BINS)
 $(BINS): $(SRC) $(OBJS)
 	$(CC) $(CFLAGS) -o $@ src/$(@:.exe=).c $(OBJS) $(LDFLAGS)
 
-%.o: %.c
+%.o: %.c %.d
 	$(CC) $< -c -o $@ $(CFLAGS)
+
+%.d: %.c
+	$(CC) $(CFLAGS) -MM -MT"$@ $(@:.d=.o)" -MP -MF $@ $<
 
 clean:
 	$(foreach c, $(BINS), $(RM) $(c);)
 	$(RM) $(OBJS)
+	$(RM) $(AUTODEPS)
 
 install: $(BINS)
 	$(MKDIR) $(PREFIX)/bin
@@ -56,5 +60,12 @@ uninstall:
 
 test:
 	@./test.sh
+
+# create a list of auto dependencies
+AUTODEPS:= $(patsubst %.c,%.d, $(DEPS)) $(patsubst %.c,%.d, $(SRC))
+
+# include by auto dependencies
+-include $(AUTODEPS)
+
 
 .PHONY: test all clean install uninstall


### PR DESCRIPTION
Hi, I've fixed 45 missing dependencies reported.
Those issues can cause incorrect results when clib is incrementally built.
For example, any changes in "deps/list/list.h" will not cause "deps/list/list.o" to be rebuilt, which is incorrect.
I've tested it on my computer, the fixed version worked as expected.
Looking forward to your confirmation.

This is a follow-up PR of PR https://github.com/clibs/clib/pull/167. 
This PR fixes all the dependency issues reported in  [report.txt](https://github.com/clibs/clib/files/3493047/report.txt). 

@lsty
