### PR TITLE
fix(): capital -V version switch

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -57,7 +57,7 @@ $ sudo make install
   Options:
 
     -h, --help     Output this message
-    -v, --version  Output version information
+    -V, --version  Output version information
 
   Commands:
 

--- a/src/clib.c
+++ b/src/clib.c
@@ -76,7 +76,7 @@ int main(int argc, const char **argv) {
   }
 
   // version
-  if (0 == strncmp(argv[1], "-v", 2) || 0 == strncmp(argv[1], "--version", 9)) {
+  if (0 == strncmp(argv[1], "-V", 2) || 0 == strncmp(argv[1], "--version", 9)) {
     printf("%s\n", CLIB_VERSION);
     return 0;
   }


### PR DESCRIPTION
This PR address a bug in the parsing of the capital `-V` switch when checking the currently installed version.