### PR TITLE
Add `clang-format` for code formatting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ MKDIR   = mkdir -p
 
 SRC  = $(wildcard src/*.c)
 COMMON_SRC = $(wildcard src/common/*.c)
+ALL_SRC = $(wildcard src/*.c src/*.h src/common/*.c src/common/*.h)
 SDEPS = $(wildcard deps/*/*.c)
 ODEPS = $(SDEPS:.c=.o)
 DEPS = $(filter-out $(ODEPS), $(SDEPS))
@@ -77,5 +78,16 @@ AUTODEPS:= $(patsubst %.c,%.d, $(DEPS)) $(patsubst %.c,%.d, $(SRC))
 # include by auto dependencies
 -include $(AUTODEPS)
 
+# Format all source files in the repository.
+fmt:
+	@if ! command -v clang-format &> /dev/null; then \
+		echo "clang-format not found"; \
+		exit; \
+	fi
+	clang-format -i -style=LLVM $(ALL_SRC)
 
-.PHONY: test all clean install uninstall
+# Install the commit hook.
+commit-hook: scripts/pre-commit-hook.sh
+	cp -f scripts/pre-commit-hook.sh .git/hooks/pre-commit
+
+.PHONY: test all clean install uninstall fmt

--- a/Readme.md
+++ b/Readme.md
@@ -140,6 +140,8 @@ $ clib install visionmedia/mon visionmedia/every visionmedia/watch
  
  You can also find us on Gitter: https://gitter.im/clibs/clib
 
+ Before committing to the repository, please run `make commit-hook`. This installs a commit hook which formats `.c` and `.h` files.
+
 ## Articles
 
   - [Introducing Clib](https://medium.com/code-adventures/b32e6e769cb3) - introduction to clib

--- a/scripts/pre-commit-hook.sh
+++ b/scripts/pre-commit-hook.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+function format_and_restage_file {
+  local file="$1"
+  # Ensure the file exists, otherwise clang-format gets very angry.
+  if [ -f "$file" ]; then
+    clang-format -i -style=LLVM "$file"
+    git add "$file"
+  fi
+}
+
+if ! command -v clang-format &> /dev/null; then
+  echo "Unable to format staged changes: clang-format not found."
+  exit
+fi
+
+# Format each staged file (ending in `.c` or `.h`).
+for file in `git diff-index --cached --name-only HEAD | grep -iE '\.(c|h)$' ` ; do
+  format_and_restage_file "$file"
+done

--- a/src/clib-configure.c
+++ b/src/clib-configure.c
@@ -6,13 +6,13 @@
 //
 
 #include <curl/curl.h>
-#include <limits.h>
-#include <libgen.h>
-#include <string.h>
 #include <errno.h>
+#include <libgen.h>
+#include <limits.h>
 #include <stdio.h>
+#include <string.h>
 
-#if defined (__unix__) || (defined (__APPLE__) && defined (__MACH__))
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
 #include <unistd.h>
 #endif
 
@@ -27,19 +27,19 @@
 #include <unistd.h>
 #endif
 
-#include "common/clib-package.h"
 #include "common/clib-cache.h"
+#include "common/clib-package.h"
 
-#include <str-flatten/str-flatten.h>
-#include <commander/commander.h>
-#include <path-join/path-join.h>
 #include <asprintf/asprintf.h>
-#include <logger/logger.h>
+#include <commander/commander.h>
 #include <debug/debug.h>
-#include <hash/hash.h>
-#include <trim/trim.h>
-#include <list/list.h>
 #include <fs/fs.h>
+#include <hash/hash.h>
+#include <list/list.h>
+#include <logger/logger.h>
+#include <path-join/path-join.h>
+#include <str-flatten/str-flatten.h>
+#include <trim/trim.h>
 
 #include "version.h"
 
@@ -53,7 +53,8 @@
 #define MAX_THREADS 4
 #endif
 
-#if defined(_WIN32) || defined(WIN32) || defined(__MINGW32__) || defined(__MINGW64__) || defined(__CYGWIN__)
+#if defined(_WIN32) || defined(WIN32) || defined(__MINGW32__) ||               \
+    defined(__MINGW64__) || defined(__CYGWIN__)
 #define setenv(k, v, _) _putenv_s(k, v)
 #define realpath(a, b) _fullpath(a, b, strlen(a))
 #endif
@@ -73,42 +74,36 @@ struct options {
 #endif
 };
 
-const char *manifest_names[] = {
-  "clib.json",
-  "package.json",
-  0
-};
+const char *manifest_names[] = {"clib.json", "package.json", 0};
 
-clib_package_opts_t package_opts = { 0 };
+clib_package_opts_t package_opts = {0};
 clib_package_t *root_package = 0;
 
 hash_t *configured = 0;
-command_t program = { 0 };
-debug_t debugger = { 0 };
+command_t program = {0};
+debug_t debugger = {0};
 
 char **rest_argv = 0;
 int rest_offset = 0;
 int rest_argc = 0;
 
-options_t opts = {
-  .skip_cache = 0,
-  .verbose = 1,
-  .force = 0,
-  .dev = 0,
+options_t opts = {.skip_cache = 0,
+                  .verbose = 1,
+                  .force = 0,
+                  .dev = 0,
 #ifdef HAVE_PTHREADS
-  .concurrency = MAX_THREADS,
+                  .concurrency = MAX_THREADS,
 #endif
 
 #ifdef _WIN32
-  .dir = ".\\deps"
+                  .dir = ".\\deps"
 #else
-  .dir = "./deps"
+                  .dir = "./deps"
 #endif
 
 };
 
-int
-configure_package(const char *dir);
+int configure_package(const char *dir);
 
 #ifdef HAVE_PTHREADS
 pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
@@ -117,8 +112,7 @@ struct clib_package_thread {
   const char *dir;
 };
 
-void *
-configure_package_with_manifest_name_thread(void *arg) {
+void *configure_package_with_manifest_name_thread(void *arg) {
   clib_package_thread_t *wrap = arg;
   const char *dir = wrap->dir;
   configure_package(dir);
@@ -126,8 +120,7 @@ configure_package_with_manifest_name_thread(void *arg) {
 }
 #endif
 
-int
-configure_package_with_manifest_name(const char *dir, const char *file) {
+int configure_package_with_manifest_name(const char *dir, const char *file) {
   clib_package_t *package = 0;
   char *json = 0;
   int ok = 0;
@@ -172,8 +165,8 @@ configure_package_with_manifest_name(const char *dir, const char *file) {
       unsigned long int size = strlen(prefix) + 1;
       free(root_package->prefix);
       root_package->prefix = malloc(size);
-      memset((void *) root_package->prefix, 0, size);
-      memcpy((void *) root_package->prefix, prefix, size);
+      memset((void *)root_package->prefix, 0, size);
+      memcpy((void *)root_package->prefix, prefix, size);
     }
   }
 
@@ -224,14 +217,10 @@ configure_package_with_manifest_name(const char *dir, const char *file) {
   } else if (0 != package->configure) {
     char *command = 0;
     char *args = rest_argc > 0
-        ? str_flatten((const char **) rest_argv, 0, rest_argc)
-        : "";
+                     ? str_flatten((const char **)rest_argv, 0, rest_argc)
+                     : "";
 
-    asprintf(&command,
-      "cd %s && %s %s",
-      dir,
-      package->configure,
-      args);
+    asprintf(&command, "cd %s && %s %s", dir, package->configure, args);
 
     if (root_package && root_package->prefix) {
       package_opts.prefix = root_package->prefix;
@@ -246,8 +235,8 @@ configure_package_with_manifest_name(const char *dir, const char *file) {
       unsigned long int size = strlen(prefix) + 1;
       free(package->prefix);
       package->prefix = malloc(size);
-      memset((void *) package->prefix, 0, size);
-      memcpy((void *) package->prefix, prefix, size);
+      memset((void *)package->prefix, 0, size);
+      memcpy((void *)package->prefix, prefix, size);
       setenv("PREFIX", package->prefix, 1);
     }
 
@@ -282,7 +271,6 @@ configure_package_with_manifest_name(const char *dir, const char *file) {
     goto cleanup;
   }
 
-
 #ifdef HAVE_PTHREADS
   pthread_mutex_unlock(&mutex);
 #endif
@@ -314,21 +302,18 @@ configure_package_with_manifest_name(const char *dir, const char *file) {
       clib_package_thread_t *wrap = &wraps[i];
       pthread_t *thread = &threads[i];
       wrap->dir = dep_dir;
-      rc = pthread_create(
-            thread,
-            0,
-            configure_package_with_manifest_name_thread,
-            wrap);
+      rc = pthread_create(thread, 0,
+                          configure_package_with_manifest_name_thread, wrap);
 
       if (++i >= opts.concurrency) {
         for (int j = 0; j < i; ++j) {
           pthread_join(threads[j], 0);
-          free((void *) wraps[j].dir);
+          free((void *)wraps[j].dir);
         }
 
         i = 0;
       }
-#if defined (__unix__) || (defined (__APPLE__) && defined (__MACH__))
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
       if (!opts.flags) {
         usleep(1024 * 10);
       }
@@ -341,7 +326,7 @@ configure_package_with_manifest_name(const char *dir, const char *file) {
 
       rc = configure_package(dep_dir);
 
-      free((void *) dep_dir);
+      free((void *)dep_dir);
 
       if (0 != rc) {
         goto cleanup;
@@ -352,11 +337,13 @@ configure_package_with_manifest_name(const char *dir, const char *file) {
 #ifdef HAVE_PTHREADS
     for (int j = 0; j < i; ++j) {
       pthread_join(threads[j], 0);
-      free((void *) wraps[j].dir);
+      free((void *)wraps[j].dir);
     }
 #endif
 
-    if (0 != iterator) { list_iterator_destroy(iterator); }
+    if (0 != iterator) {
+      list_iterator_destroy(iterator);
+    }
   }
 
   if (opts.dev && 0 != package->development) {
@@ -386,21 +373,18 @@ configure_package_with_manifest_name(const char *dir, const char *file) {
       clib_package_thread_t *wrap = &wraps[i];
       pthread_t *thread = &threads[i];
       wrap->dir = dep_dir;
-      rc = pthread_create(
-            thread,
-            0,
-            configure_package_with_manifest_name_thread,
-            wrap);
+      rc = pthread_create(thread, 0,
+                          configure_package_with_manifest_name_thread, wrap);
 
       if (++i >= opts.concurrency) {
         for (int j = 0; j < i; ++j) {
           pthread_join(threads[j], 0);
-          free((void *) wraps[j].dir);
+          free((void *)wraps[j].dir);
         }
 
         i = 0;
       }
-#if defined (__unix__) || (defined (__APPLE__) && defined (__MACH__))
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
       if (!opts.flags) {
         usleep(1024 * 10);
       }
@@ -413,7 +397,7 @@ configure_package_with_manifest_name(const char *dir, const char *file) {
 
       rc = configure_package(dep_dir);
 
-      free((void *) dep_dir);
+      free((void *)dep_dir);
 
       if (0 != rc) {
         goto cleanup;
@@ -424,24 +408,31 @@ configure_package_with_manifest_name(const char *dir, const char *file) {
 #ifdef HAVE_PTHREADS
     for (int j = 0; j < i; ++j) {
       pthread_join(threads[j], 0);
-      free((void *) wraps[j].dir);
+      free((void *)wraps[j].dir);
     }
 #endif
 
-    if (0 != iterator) { list_iterator_destroy(iterator); }
+    if (0 != iterator) {
+      list_iterator_destroy(iterator);
+    }
   }
 
 cleanup:
-  if (0 != package) { clib_package_free(package); }
-  if (0 != json) { free(json); }
+  if (0 != package) {
+    clib_package_free(package);
+  }
+  if (0 != json) {
+    free(json);
+  }
   if (0 == ok) {
-    if (0 != path) { free(path); }
+    if (0 != path) {
+      free(path);
+    }
   }
   return rc;
 }
 
-int
-configure_package(const char *dir) {
+int configure_package(const char *dir) {
   const char *name = NULL;
   unsigned int i = 0;
   int rc = 0;
@@ -454,58 +445,49 @@ configure_package(const char *dir) {
   return rc;
 }
 
-static void
-setopt_skip_cache(command_t *self) {
+static void setopt_skip_cache(command_t *self) {
   opts.skip_cache = 1;
   debug(&debugger, "set skip cache flag");
 }
 
-static void
-setopt_dev(command_t *self) {
+static void setopt_dev(command_t *self) {
   opts.dev = 1;
   debug(&debugger, "set dev flag");
 }
 
-static void
-setopt_force(command_t *self) {
+static void setopt_force(command_t *self) {
   opts.force = 1;
   debug(&debugger, "set force flag");
 }
 
-static void
-setopt_global(command_t *self) {
+static void setopt_global(command_t *self) {
   opts.global = 1;
   debug(&debugger, "set global flag");
 }
 
-static void
-setopt_flags(command_t *self) {
+static void setopt_flags(command_t *self) {
   opts.flags = 1;
   opts.verbose = 0;
   debug(&debugger, "set flags flag");
 }
 
-static void
-setopt_prefix(command_t *self) {
-  opts.prefix = (char *) self->arg;
+static void setopt_prefix(command_t *self) {
+  opts.prefix = (char *)self->arg;
   debug(&debugger, "set prefix: %s", opts.prefix);
 }
 
-static void
-setopt_dir(command_t *self) {
-  opts.dir = (char *) self->arg;
+static void setopt_dir(command_t *self) {
+  opts.dir = (char *)self->arg;
   debug(&debugger, "set dir: %s", opts.dir);
 }
 
-static void
-setopt_quiet(command_t *self) {
+static void setopt_quiet(command_t *self) {
   opts.verbose = 0;
   debug(&debugger, "set quiet flag");
 }
 
 #ifdef HAVE_PTHREADS
-static void
-setopt_concurrency(command_t *self) {
+static void setopt_concurrency(command_t *self) {
   if (self->arg) {
     opts.concurrency = atol(self->arg);
     debug(&debugger, "set concurrency: %lu", opts.concurrency);
@@ -513,8 +495,7 @@ setopt_concurrency(command_t *self) {
 }
 #endif
 
-int
-main(int argc, char **argv) {
+int main(int argc, char **argv) {
   int rc = 0;
 
 #ifdef PATH_MAX
@@ -536,59 +517,38 @@ main(int argc, char **argv) {
   configured = hash_new();
   hash_set(configured, strdup("__" PROGRAM_NAME "__"), CLIB_VERSION);
 
-  command_init(&program , PROGRAM_NAME, CLIB_VERSION);
+  command_init(&program, PROGRAM_NAME, CLIB_VERSION);
   debug_init(&debugger, PROGRAM_NAME);
 
   program.usage = "[options] [name ...]";
 
-  command_option(&program,
-    "-o",
-    "--out <dir>",
-    "change the output directory [deps]",
-    setopt_dir);
+  command_option(&program, "-o", "--out <dir>",
+                 "change the output directory [deps]", setopt_dir);
 
-  command_option(&program,
-    "-P",
-    "--prefix <dir>",
-    "change the prefix directory (usually '/usr/local')",
-    setopt_prefix);
+  command_option(&program, "-P", "--prefix <dir>",
+                 "change the prefix directory (usually '/usr/local')",
+                 setopt_prefix);
 
-  command_option(&program,
-    "-q",
-    "--quiet",
-    "disable verbose output",
-    setopt_quiet);
+  command_option(&program, "-q", "--quiet", "disable verbose output",
+                 setopt_quiet);
 
-  command_option(&program,
-    "-d",
-    "--dev",
-    "configure development dependencies",
-    setopt_dev);
+  command_option(&program, "-d", "--dev", "configure development dependencies",
+                 setopt_dev);
 
-  command_option(&program,
-    "-f",
-    "--force",
-    "force the action of something, like overwriting a file",
-    setopt_force);
+  command_option(&program, "-f", "--force",
+                 "force the action of something, like overwriting a file",
+                 setopt_force);
 
-  command_option(&program,
-    "--cflags",
-    "--flags",
-    "output compiler flags instead of configuring",
-    setopt_flags);
+  command_option(&program, "--cflags", "--flags",
+                 "output compiler flags instead of configuring", setopt_flags);
 
-  command_option(&program,
-     "-c",
-     "--skip-cache",
-     "skip cache when configuring",
-     setopt_skip_cache);
+  command_option(&program, "-c", "--skip-cache", "skip cache when configuring",
+                 setopt_skip_cache);
 
 #ifdef HAVE_PTHREADS
-  command_option(&program,
-     "-C",
-     "--concurrency <number>",
-     "Set concurrency (default: " S(MAX_THREADS) ")",
-     setopt_concurrency);
+  command_option(&program, "-C", "--concurrency <number>",
+                 "Set concurrency (default: " S(MAX_THREADS) ")",
+                 setopt_concurrency);
 #endif
 
   command_parse(&program, argc, argv);
@@ -599,8 +559,8 @@ main(int argc, char **argv) {
     realpath(opts.dir, dir);
     unsigned long int size = strlen(dir) + 1;
     opts.dir = malloc(size);
-    memset((void *) opts.dir, 0, size);
-    memcpy((void *) opts.dir, dir, size);
+    memset((void *)opts.dir, 0, size);
+    memcpy((void *)opts.dir, dir, size);
   }
 
   if (opts.prefix) {
@@ -609,8 +569,8 @@ main(int argc, char **argv) {
     realpath(opts.prefix, prefix);
     unsigned long int size = strlen(prefix) + 1;
     opts.prefix = malloc(size);
-    memset((void *) opts.prefix, 0, size);
-    memcpy((void *) opts.prefix, prefix, size);
+    memset((void *)opts.prefix, 0, size);
+    memcpy((void *)opts.prefix, prefix, size);
   }
 
   rest_offset = program.argc;
@@ -624,7 +584,7 @@ main(int argc, char **argv) {
         rest = 1;
         rest_offset = i + 1;
       } else if (arg && rest) {
-        (void) rest_argc++;
+        (void)rest_argc++;
       }
     } while (program.nargv[++i]);
   }
@@ -684,18 +644,13 @@ main(int argc, char **argv) {
 
       fs_stats *stats = fs_stat(dep);
 
-      if (
-        stats &&
-        (S_IFREG == (stats->st_mode & S_IFMT)
+      if (stats && (S_IFREG == (stats->st_mode & S_IFMT)
 #if defined(__unix__) || defined(__linux__) || defined(_POSIX_VERSION)
-      || S_IFLNK == (stats->st_mode & S_IFMT)
+                    || S_IFLNK == (stats->st_mode & S_IFMT)
 #endif
-        )
-      ) {
+                        )) {
         dep = basename(dep);
-        rc = configure_package_with_manifest_name(
-          dirname(dep),
-          basename(dep));
+        rc = configure_package_with_manifest_name(dirname(dep), basename(dep));
       } else {
         rc = configure_package(dep);
 
@@ -715,10 +670,10 @@ main(int argc, char **argv) {
   int total_configured = 0;
   hash_each(configured, {
     if (0 == strncmp("t", val, 1)) {
-      (void) total_configured++;
+      (void)total_configured++;
     }
     if (0 != key) {
-      free((void *) key);
+      free((void *)key);
     }
   });
 
@@ -728,7 +683,7 @@ main(int argc, char **argv) {
   clib_package_cleanup();
 
   if (opts.dir) {
-    free((void *) opts.dir);
+    free((void *)opts.dir);
   }
 
   if (opts.prefix) {
@@ -748,7 +703,7 @@ main(int argc, char **argv) {
     }
 
     if (opts.verbose) {
-      if (total_configured > 1){
+      if (total_configured > 1) {
         logger_info("info", "configured %d packages", total_configured);
       } else if (1 == total_configured) {
         logger_info("info", "configured 1 package");

--- a/src/clib-init.c
+++ b/src/clib-init.c
@@ -5,20 +5,21 @@
 // MIT licensed
 //
 
-#include <stdio.h>
-#include <string.h>
-#include <stdlib.h>
-#include <unistd.h>
-#include "fs/fs.h"
 #include "asprintf/asprintf.h"
 #include "commander/commander.h"
 #include "common/clib-package.h"
-#include "logger/logger.h"
 #include "debug/debug.h"
+#include "fs/fs.h"
+#include "logger/logger.h"
 #include "parson/parson.h"
 #include "version.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
 
-#if defined(_WIN32) || defined(WIN32) || defined(__MINGW32__) || defined(__MINGW64__) || defined(__CYGWIN__)
+#if defined(_WIN32) || defined(WIN32) || defined(__MINGW32__) ||               \
+    defined(__MINGW64__) || defined(__CYGWIN__)
 #define setenv(k, v, _) _putenv_s(k, v)
 #define realpath(a, b) _fullpath(a, b, strlen(a))
 #endif
@@ -26,7 +27,7 @@
 debug_t debugger;
 
 struct options {
-  char* manifest;
+  char *manifest;
   int verbose;
 };
 
@@ -36,15 +37,13 @@ static struct options opts;
  * Option setters.
  */
 
-static void
-setopt_quiet(command_t *self) {
+static void setopt_quiet(command_t *self) {
   opts.verbose = 0;
   debug(&debugger, "set quiet flag");
 }
 
-static void
-setopt_manifest_file(command_t *self) {
-  opts.manifest = (char *) self->arg;
+static void setopt_manifest_file(command_t *self) {
+  opts.manifest = (char *)self->arg;
   debug(&debugger, "set manifest: %s", opts.manifest);
 }
 
@@ -52,46 +51,40 @@ setopt_manifest_file(command_t *self) {
  * Program.
  */
 
-static
-char* find_basepath() {
-  char cwd[4096] = { 0 };
+static char *find_basepath() {
+  char cwd[4096] = {0};
   getcwd(cwd, 4096);
-  char* walk = cwd + strlen(cwd);
-  while(*(--walk) != '/');
-  char* basepath = malloc((size_t)(walk - cwd));
+  char *walk = cwd + strlen(cwd);
+  while (*(--walk) != '/')
+    ;
+  char *basepath = malloc((size_t)(walk - cwd));
   strncpy(basepath, walk + 1, (size_t)(walk - cwd));
   return basepath;
 }
 
-static
-void getinput(char* buffer, size_t s) {
-  char* walk = buffer;
+static void getinput(char *buffer, size_t s) {
+  char *walk = buffer;
   int c = 0;
-  while ((walk - s) != buffer &&
-         (c = fgetc(stdin)) &&
-         c != '\n' && c != 0) {
+  while ((walk - s) != buffer && (c = fgetc(stdin)) && c != '\n' && c != 0) {
     *(walk++) = c;
   }
 }
 
-static
-void ask_for(JSON_Object* root,
-             const char* key,
-             const char* default_value,
-             const char* question) {
-  static char buffer[512] = { 0 };
+static void ask_for(JSON_Object *root, const char *key,
+                    const char *default_value, const char *question) {
+  static char buffer[512] = {0};
   memset(buffer, '\0', 512);
   printf("%s", question);
   getinput(buffer, 512);
-  char* value = (char*)(strlen(buffer) > 0 ? buffer : default_value);
+  char *value = (char *)(strlen(buffer) > 0 ? buffer : default_value);
   json_object_set_string(root, key, value);
 }
 
-static inline size_t
-write_to_file(const char* manifest, const char* str, size_t length) {
+static inline size_t write_to_file(const char *manifest, const char *str,
+                                   size_t length) {
   size_t wrote = 0;
 
-  FILE* file = fopen(manifest, "w+");
+  FILE *file = fopen(manifest, "w+");
   if (!file) {
     debug(&debugger, "Cannot open %s file.", manifest);
     return 0;
@@ -103,10 +96,9 @@ write_to_file(const char* manifest, const char* str, size_t length) {
   return length - wrote;
 }
 
-static int
-write_package_file(const char* manifest, JSON_Value* pkg) {
+static int write_package_file(const char *manifest, JSON_Value *pkg) {
   int rc = 0;
-  char* package = json_serialize_to_string_pretty(pkg);
+  char *package = json_serialize_to_string_pretty(pkg);
 
   if (0 != write_to_file(manifest, package, strlen(package))) {
     logger_error("Failed to write to %s", manifest);
@@ -116,7 +108,7 @@ write_package_file(const char* manifest, JSON_Value* pkg) {
 
   debug(&debugger, "Wrote %s file.", manifest);
 
- e1:
+e1:
   json_free_serialized_string(package);
 
   return rc;
@@ -126,8 +118,7 @@ write_package_file(const char* manifest, JSON_Value* pkg) {
  * Entry point.
  */
 
-int
-main(int argc, char *argv[]) {
+int main(int argc, char *argv[]) {
   int exit_code = 0;
   opts.verbose = 1;
   opts.manifest = "clib.json";
@@ -136,31 +127,24 @@ main(int argc, char *argv[]) {
 
   command_t program;
 
-  command_init(&program
-    , "clib-init"
-    , CLIB_VERSION);
+  command_init(&program, "clib-init", CLIB_VERSION);
 
   program.usage = "[options]";
 
-  command_option(&program
-                 , "-q"
-                 , "--quiet"
-                 , "disable verbose output"
-                 , setopt_quiet);
-  command_option(&program
-                 , "-M"
-                 , "--manifest <filename>"
-                 , "give a manifest of the manifest file. (default: clib.json)"
-                 , setopt_manifest_file);
+  command_option(&program, "-q", "--quiet", "disable verbose output",
+                 setopt_quiet);
+  command_option(&program, "-M", "--manifest <filename>",
+                 "give a manifest of the manifest file. (default: clib.json)",
+                 setopt_manifest_file);
   command_parse(&program, argc, argv);
 
   debug(&debugger, "%d arguments", program.argc);
 
-  JSON_Value* json = json_value_init_object();
-  JSON_Object* root = json_object(json);
+  JSON_Value *json = json_value_init_object();
+  JSON_Object *root = json_object(json);
 
-  char* basepath = find_basepath();
-  char* package_name = NULL;
+  char *basepath = find_basepath();
+  char *package_name = NULL;
 
   int rc = asprintf(&package_name, "package name (%s): ", basepath);
   if (-1 == rc) {
@@ -173,7 +157,7 @@ main(int argc, char *argv[]) {
 
   exit_code = write_package_file(opts.manifest, json);
 
- end:
+end:
   free(package_name);
   free(basepath);
 

--- a/src/clib-install.c
+++ b/src/clib-install.c
@@ -5,23 +5,23 @@
 // MIT licensed
 //
 
-#include <curl/curl.h>
-#include <stdio.h>
-#include <string.h>
-#include <stdlib.h>
-#include <limits.h>
-#include <libgen.h>
-#include "fs/fs.h"
 #include "commander/commander.h"
-#include "common/clib-package.h"
 #include "common/clib-cache.h"
+#include "common/clib-package.h"
+#include "debug/debug.h"
+#include "fs/fs.h"
 #include "http-get/http-get.h"
 #include "logger/logger.h"
-#include "debug/debug.h"
 #include "parson/parson.h"
 #include "str-concat/str-concat.h"
 #include "str-replace/str-replace.h"
 #include "version.h"
+#include <curl/curl.h>
+#include <libgen.h>
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 #define CLIB_PACKAGE_CACHE_TIME 30 * 24 * 60 * 60
 
@@ -32,14 +32,15 @@
 #define MAX_THREADS 12
 #endif
 
-#if defined(_WIN32) || defined(WIN32) || defined(__MINGW32__) || defined(__MINGW64__) || defined(__CYGWIN__)
+#if defined(_WIN32) || defined(WIN32) || defined(__MINGW32__) ||               \
+    defined(__MINGW64__) || defined(__CYGWIN__)
 #define setenv(k, v, _) _putenv_s(k, v)
 #define realpath(a, b) _fullpath(a, b, strlen(a))
 #endif
 
 extern CURLSH *clib_package_curl_share;
 
-debug_t debugger = { 0 };
+debug_t debugger = {0};
 
 struct options {
   const char *dir;
@@ -57,78 +58,64 @@ struct options {
 #endif
 };
 
-static struct options opts = { 0 };
+static struct options opts = {0};
 
-static const char *manifest_names[] = {
-  "clib.json",
-  "package.json",
-  NULL
-};
+static const char *manifest_names[] = {"clib.json", "package.json", NULL};
 
-static clib_package_opts_t package_opts = { 0 };
+static clib_package_opts_t package_opts = {0};
 static clib_package_t *root_package = NULL;
 
 /**
  * Option setters.
  */
 
-static void
-setopt_dir(command_t *self) {
-  opts.dir = (char *) self->arg;
+static void setopt_dir(command_t *self) {
+  opts.dir = (char *)self->arg;
   debug(&debugger, "set dir: %s", opts.dir);
 }
 
-static void
-setopt_prefix(command_t *self) {
-  opts.prefix = (char *) self->arg;
+static void setopt_prefix(command_t *self) {
+  opts.prefix = (char *)self->arg;
   debug(&debugger, "set prefix: %s", opts.prefix);
 }
 
-static void
-setopt_token(command_t *self) {
-  opts.token = (char *) self->arg;
+static void setopt_token(command_t *self) {
+  opts.token = (char *)self->arg;
   debug(&debugger, "set token: %s", opts.token);
 }
 
-static void
-setopt_quiet(command_t *self) {
+static void setopt_quiet(command_t *self) {
   opts.verbose = 0;
   debug(&debugger, "set quiet flag");
 }
 
-static void
-setopt_dev(command_t *self) {
+static void setopt_dev(command_t *self) {
   opts.dev = 1;
   debug(&debugger, "set development flag");
 }
 
-static void
-setopt_save(command_t *self) {
+static void setopt_save(command_t *self) {
   opts.save = 1;
   debug(&debugger, "set save flag");
 }
 
-static void
-setopt_savedev(command_t *self) {
+static void setopt_savedev(command_t *self) {
   opts.savedev = 1;
   debug(&debugger, "set savedev flag");
 }
 
-static void
-setopt_force(command_t *self) {
+static void setopt_force(command_t *self) {
   opts.force = 1;
   debug(&debugger, "set force flag");
 }
 
-static void
-setopt_global(command_t *self) {
+static void setopt_global(command_t *self) {
   opts.global = 1;
   debug(&debugger, "set global flag");
 }
 
 #ifdef HAVE_PTHREADS
-static void
-setopt_concurrency(command_t *self) {
+static void setopt_concurrency(command_t *self) {
   if (self->arg) {
     opts.concurrency = atol(self->arg);
     debug(&debugger, "set concurrency: %lu", opts.concurrency);
@@ -136,14 +123,12 @@ setopt_concurrency(command_t *self) {
 }
 #endif
 
-static void
-setopt_skip_cache(command_t *self) {
+static void setopt_skip_cache(command_t *self) {
   opts.skip_cache = 1;
   debug(&debugger, "set skip cache flag");
 }
 
-static int
-install_local_packages_with_package_name(const char *file) {
+static int install_local_packages_with_package_name(const char *file) {
   if (-1 == fs_exists(file)) {
     logger_error("error", "Missing clib.json or package.json");
     return 1;
@@ -151,22 +136,25 @@ install_local_packages_with_package_name(const char *file) {
 
   debug(&debugger, "reading local clib.json or package.json");
   char *json = fs_read(file);
-  if (NULL == json) return 1;
-
+  if (NULL == json)
+    return 1;
 
   clib_package_t *pkg = clib_package_new(json, opts.verbose);
-  if (NULL == pkg) goto e1;
+  if (NULL == pkg)
+    goto e1;
 
   if (pkg->prefix) {
     setenv("PREFIX", pkg->prefix, 1);
   }
 
   int rc = clib_package_install_dependencies(pkg, opts.dir, opts.verbose);
-  if (-1 == rc) goto e2;
+  if (-1 == rc)
+    goto e2;
 
   if (opts.dev) {
     rc = clib_package_install_development(pkg, opts.dir, opts.verbose);
-    if (-1 == rc) goto e2;
+    if (-1 == rc)
+      goto e2;
   }
 
   free(json);
@@ -183,8 +171,7 @@ e1:
 /**
  * Install dependency packages at `pwd`.
  */
-static int
-install_local_packages() {
+static int install_local_packages() {
   const char *name = NULL;
   unsigned int i = 0;
   int rc = 0;
@@ -197,16 +184,18 @@ install_local_packages() {
   return rc;
 }
 
-static int
-write_dependency_with_package_name(clib_package_t *pkg, char* prefix, const char *file) {
+static int write_dependency_with_package_name(clib_package_t *pkg, char *prefix,
+                                              const char *file) {
   JSON_Value *packageJson = json_parse_file(file);
   JSON_Object *packageJsonObject = json_object(packageJson);
   JSON_Value *newDepSectionValue = NULL;
 
-  if (NULL == packageJson || NULL == packageJsonObject) return 1;
+  if (NULL == packageJson || NULL == packageJsonObject)
+    return 1;
 
   // If the dependency section doesn't exist then create it
-  JSON_Object *depSection = json_object_dotget_object(packageJsonObject, prefix);
+  JSON_Object *depSection =
+      json_object_dotget_object(packageJsonObject, prefix);
   if (NULL == depSection) {
     newDepSectionValue = json_value_init_object();
     depSection = json_value_get_object(newDepSectionValue);
@@ -225,8 +214,7 @@ write_dependency_with_package_name(clib_package_t *pkg, char* prefix, const char
 /**
  * Writes out a dependency to clib.json or package.json
  */
-static int
-write_dependency(clib_package_t *pkg, char* prefix) {
+static int write_dependency(clib_package_t *pkg, char *prefix) {
   const char *name = NULL;
   unsigned int i = 0;
   int rc = 0;
@@ -242,8 +230,7 @@ write_dependency(clib_package_t *pkg, char* prefix) {
 /**
  * Save a dependency to clib.json or package.json.
  */
-static int
-save_dependency(clib_package_t *pkg) {
+static int save_dependency(clib_package_t *pkg) {
   debug(&debugger, "saving dependency %s at %s", pkg->name, pkg->version);
   return write_dependency(pkg, "dependencies");
 }
@@ -251,8 +238,7 @@ save_dependency(clib_package_t *pkg) {
 /**
  * Save a development dependency to clib.json or package.json.
  */
-static int
-save_dev_dependency(clib_package_t *pkg) {
+static int save_dev_dependency(clib_package_t *pkg) {
   debug(&debugger, "saving dev dependency %s at %s", pkg->name, pkg->version);
   return write_dependency(pkg, "development");
 }
@@ -261,9 +247,8 @@ save_dev_dependency(clib_package_t *pkg) {
  * Create and install a package from `slug`.
  */
 
-static int
-install_package(const char *slug) {
-  clib_package_t *pkg  = NULL;
+static int install_package(const char *slug) {
+  clib_package_t *pkg = NULL;
   int rc;
 
 #ifdef PATH_MAX
@@ -300,14 +285,11 @@ install_package(const char *slug) {
 
   if (0 == fs_exists(slug)) {
     fs_stats *stats = fs_stat(slug);
-    if (
-      NULL != stats &&
-      (S_IFREG == (stats->st_mode & S_IFMT)
+    if (NULL != stats && (S_IFREG == (stats->st_mode & S_IFMT)
 #if defined(__unix__) || defined(__linux__) || defined(_POSIX_VERSION)
-      || S_IFLNK == (stats->st_mode & S_IFMT)
+                          || S_IFLNK == (stats->st_mode & S_IFMT)
 #endif
-      )
-    ) {
+                              )) {
       free(stats);
       return install_local_packages_with_package_name(slug);
     }
@@ -321,7 +303,8 @@ install_package(const char *slug) {
     pkg = clib_package_new_from_slug(slug, opts.verbose);
   }
 
-  if (NULL == pkg) return -1;
+  if (NULL == pkg)
+    return -1;
 
   if (root_package && root_package->prefix) {
     package_opts.prefix = root_package->prefix;
@@ -344,8 +327,10 @@ install_package(const char *slug) {
     pkg->repo = strdup(slug);
   }
 
-  if (opts.save) save_dependency(pkg);
-  if (opts.savedev) save_dev_dependency(pkg);
+  if (opts.save)
+    save_dependency(pkg);
+  if (opts.savedev)
+    save_dev_dependency(pkg);
 
 cleanup:
   clib_package_free(pkg);
@@ -356,11 +341,11 @@ cleanup:
  * Install the given `pkgs`.
  */
 
-static int
-install_packages(int n, char *pkgs[]) {
+static int install_packages(int n, char *pkgs[]) {
   for (int i = 0; i < n; i++) {
     debug(&debugger, "install %s (%d)", pkgs[i], i);
-    if (-1 == install_package(pkgs[i])) return 1;
+    if (-1 == install_package(pkgs[i]))
+      return 1;
   }
   return 0;
 }
@@ -369,8 +354,7 @@ install_packages(int n, char *pkgs[]) {
  * Entry point.
  */
 
-int
-main(int argc, char *argv[]) {
+int main(int argc, char *argv[]) {
 #ifdef _WIN32
   opts.dir = ".\\deps";
 #else
@@ -389,76 +373,45 @@ main(int argc, char *argv[]) {
 
   debug_init(&debugger, "clib-install");
 
-  //30 days expiration
+  // 30 days expiration
   clib_cache_init(CLIB_PACKAGE_CACHE_TIME);
 
   command_t program;
 
-  command_init(&program
-    , "clib-install"
-    , CLIB_VERSION);
+  command_init(&program, "clib-install", CLIB_VERSION);
 
   program.usage = "[options] [name ...]";
 
-  command_option(&program
-    , "-o"
-    , "--out <dir>"
-    , "change the output directory [deps]"
-    , setopt_dir);
-  command_option(&program
-    , "-P"
-    , "--prefix <dir>"
-    , "change the prefix directory (usually '/usr/local')"
-    , setopt_prefix);
-  command_option(&program
-    , "-q"
-    , "--quiet"
-    , "disable verbose output"
-    , setopt_quiet);
-  command_option(&program
-    , "-d"
-    , "--dev"
-    , "install development dependencies"
-    , setopt_dev);
-  command_option(&program
-    , "-S"
-    , "--save"
-    , "save dependency in clib.json or package.json"
-    , setopt_save);
-  command_option(&program
-      , "-D"
-      , "--save-dev"
-      , "save development dependency in clib.json or package.json"
-      , setopt_savedev);
-  command_option(&program
-      , "-f"
-      , "--force"
-      , "force the action of something, like overwriting a file"
-      , setopt_force);
-  command_option(&program
-      , "-c"
-      , "--skip-cache"
-      , "skip cache when installing"
-      , setopt_skip_cache);
-  command_option(&program
-      , "-g"
-      , "--global"
-      , "global install, don't write to output dir (default: deps/)"
-      , setopt_global);
-  command_option(&program
-      , "-t"
-      , "--token <token>"
-      , "Access token used to read private content"
-      , setopt_token);
+  command_option(&program, "-o", "--out <dir>",
+                 "change the output directory [deps]", setopt_dir);
+  command_option(&program, "-P", "--prefix <dir>",
+                 "change the prefix directory (usually '/usr/local')",
+                 setopt_prefix);
+  command_option(&program, "-q", "--quiet", "disable verbose output",
+                 setopt_quiet);
+  command_option(&program, "-d", "--dev", "install development dependencies",
+                 setopt_dev);
+  command_option(&program, "-S", "--save",
+                 "save dependency in clib.json or package.json", setopt_save);
+  command_option(&program, "-D", "--save-dev",
+                 "save development dependency in clib.json or package.json",
+                 setopt_savedev);
+  command_option(&program, "-f", "--force",
+                 "force the action of something, like overwriting a file",
+                 setopt_force);
+  command_option(&program, "-c", "--skip-cache", "skip cache when installing",
+                 setopt_skip_cache);
+  command_option(&program, "-g", "--global",
+                 "global install, don't write to output dir (default: deps/)",
+                 setopt_global);
+  command_option(&program, "-t", "--token <token>",
+                 "Access token used to read private content", setopt_token);
 #ifdef HAVE_PTHREADS
-  command_option(&program,
-     "-C",
-     "--concurrency <number>",
-     "Set concurrency (default: " S(MAX_THREADS) ")",
-     setopt_concurrency);
+  command_option(&program, "-C", "--concurrency <number>",
+                 "Set concurrency (default: " S(MAX_THREADS) ")",
+                 setopt_concurrency);
 #endif
   command_parse(&program, argc, argv);
-
 
   debug(&debugger, "%d arguments", program.argc);
 
@@ -472,8 +425,8 @@ main(int argc, char *argv[]) {
     realpath(opts.prefix, prefix);
     unsigned long int size = strlen(prefix) + 1;
     opts.prefix = malloc(size);
-    memset((void *) opts.prefix, 0, size);
-    memcpy((void *) opts.prefix, prefix, size);
+    memset((void *)opts.prefix, 0, size);
+    memcpy((void *)opts.prefix, prefix, size);
   }
 
   clib_cache_init(CLIB_PACKAGE_CACHE_TIME);
@@ -499,9 +452,8 @@ main(int argc, char *argv[]) {
     setenv("CLIB_FORCE", "1", 1);
   }
 
-  int code = 0 == program.argc
-    ? install_local_packages()
-    : install_packages(program.argc, program.argv);
+  int code = 0 == program.argc ? install_local_packages()
+                               : install_packages(program.argc, program.argv);
 
   curl_global_cleanup();
   clib_package_cleanup();

--- a/src/clib-search.c
+++ b/src/clib-search.c
@@ -5,30 +5,31 @@
 // MIT licensed
 //
 
+#include "asprintf/asprintf.h"
+#include "case/case.h"
+#include "commander/commander.h"
+#include "common/clib-cache.h"
+#include "common/clib-package.h"
+#include "console-colors/console-colors.h"
+#include "debug/debug.h"
+#include "fs/fs.h"
+#include "http-get/http-get.h"
+#include "logger/logger.h"
+#include "parson/parson.h"
+#include "strdup/strdup.h"
+#include "tempdir/tempdir.h"
+#include "version.h"
+#include "wiki-registry/wiki-registry.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
-#include "case/case.h"
-#include "commander/commander.h"
-#include "tempdir/tempdir.h"
-#include "fs/fs.h"
-#include "http-get/http-get.h"
-#include "asprintf/asprintf.h"
-#include "wiki-registry/wiki-registry.h"
-#include "common/clib-package.h"
-#include "console-colors/console-colors.h"
-#include "strdup/strdup.h"
-#include "logger/logger.h"
-#include "debug/debug.h"
-#include "version.h"
-#include "common/clib-cache.h"
-#include "parson/parson.h"
 
 #define CLIB_WIKI_URL "https://github.com/clibs/clib/wiki/Packages"
 #define CLIB_SEARCH_CACHE_TIME 1 * 24 * 60 * 60
 
-#if defined(_WIN32) || defined(WIN32) || defined(__MINGW32__) || defined(__MINGW64__) || defined(__CYGWIN__)
+#if defined(_WIN32) || defined(WIN32) || defined(__MINGW32__) ||               \
+    defined(__MINGW64__) || defined(__CYGWIN__)
 #define setenv(k, v, _) _putenv_s(k, v)
 #define realpath(a, b) _fullpath(a, b, strlen(a))
 #endif
@@ -39,46 +40,37 @@ static int opt_color;
 static int opt_cache;
 static int opt_json;
 
-static void
-setopt_nocolor(command_t *self) {
-    opt_color = 0;
-}
+static void setopt_nocolor(command_t *self) { opt_color = 0; }
 
-static void
-setopt_nocache(command_t *self) {
-    opt_cache = 0;
-}
+static void setopt_nocache(command_t *self) { opt_cache = 0; }
 
-static void
-setopt_json(command_t *self) {
-    opt_json = 1;
-}
+static void setopt_json(command_t *self) { opt_json = 1; }
 
-#define COMPARE(v) {                \
-  if (NULL == v) {                  \
-    rc = 0;                         \
-    goto cleanup;                   \
-  }                                 \
-  case_lower(v);                    \
-  for (int i = 0; i < count; i++) { \
-    if (strstr(v, args[i])) {       \
-      rc = 1;                       \
-      break;                        \
-    }                               \
-  }                                 \
-}
+#define COMPARE(v)                                                             \
+  {                                                                            \
+    if (NULL == v) {                                                           \
+      rc = 0;                                                                  \
+      goto cleanup;                                                            \
+    }                                                                          \
+    case_lower(v);                                                             \
+    for (int i = 0; i < count; i++) {                                          \
+      if (strstr(v, args[i])) {                                                \
+        rc = 1;                                                                \
+        break;                                                                 \
+      }                                                                        \
+    }                                                                          \
+  }
 
-static int
-matches(int count, char *args[], wiki_package_t *pkg) {
+static int matches(int count, char *args[], wiki_package_t *pkg) {
   // Display all packages if there's no query
-  if (0 == count) return 1;
+  if (0 == count)
+    return 1;
 
   char *description = NULL;
   char *name = NULL;
   char *repo = NULL;
   char *href = NULL;
   int rc = 0;
-
 
   name = clib_package_parse_name(pkg->repo);
   COMPARE(name);
@@ -98,14 +90,13 @@ cleanup:
   return rc;
 }
 
-static char *
-wiki_html_cache() {
+static char *wiki_html_cache() {
 
   if (clib_cache_has_search() && opt_cache) {
     char *data = clib_cache_read_search();
 
     if (data) {
-        return data;
+      return data;
     }
 
     goto set_cache;
@@ -115,20 +106,24 @@ set_cache:
 
   debug(&debugger, "setting cache from %s", CLIB_WIKI_URL);
   http_get_response_t *res = http_get(CLIB_WIKI_URL);
-  if (!res->ok) return NULL;
+  if (!res->ok)
+    return NULL;
 
   char *html = strdup(res->data);
-  if (NULL == html) return NULL;
+  if (NULL == html)
+    return NULL;
   http_get_free(res);
 
-  if (NULL == html) return html;
+  if (NULL == html)
+    return html;
   clib_cache_save_search(html);
   debug(&debugger, "wrote cach");
   return html;
 }
 
-static void
-display_package(const wiki_package_t *pkg, cc_color_t fg_color_highlight, cc_color_t fg_color_text) {
+static void display_package(const wiki_package_t *pkg,
+                            cc_color_t fg_color_highlight,
+                            cc_color_t fg_color_text) {
   cc_fprintf(fg_color_highlight, stdout, "  %s\n", pkg->repo);
   printf("  url: ");
   cc_fprintf(fg_color_text, stdout, "%s\n", pkg->href);
@@ -137,9 +132,8 @@ display_package(const wiki_package_t *pkg, cc_color_t fg_color_highlight, cc_col
   printf("\n");
 }
 
-static void
-add_package_to_json(const wiki_package_t *pkg, JSON_Array *json_list)
-{
+static void add_package_to_json(const wiki_package_t *pkg,
+                                JSON_Array *json_list) {
   JSON_Value *json_pkg_root = json_value_init_object();
   JSON_Object *json_pkg = json_value_get_object(json_pkg_root);
 
@@ -151,8 +145,7 @@ add_package_to_json(const wiki_package_t *pkg, JSON_Array *json_list)
   json_array_append_value(json_list, json_pkg_root);
 }
 
-int
-main(int argc, char *argv[]) {
+int main(int argc, char *argv[]) {
   opt_color = 1;
   opt_cache = 1;
 
@@ -164,41 +157,23 @@ main(int argc, char *argv[]) {
   command_init(&program, "clib-search", CLIB_VERSION);
   program.usage = "[options] [query ...]";
 
-  command_option(
-      &program
-    , "-n"
-    , "--no-color"
-    , "don't colorize output"
-    , setopt_nocolor
-  );
+  command_option(&program, "-n", "--no-color", "don't colorize output",
+                 setopt_nocolor);
 
-  command_option(
-      &program
-    , "-c"
-    , "--skip-cache"
-    , "skip the search cache"
-    , setopt_nocache
-  );
+  command_option(&program, "-c", "--skip-cache", "skip the search cache",
+                 setopt_nocache);
 
-  command_option(
-      &program
-    , "-j"
-    , "--json"
-    , "generate a serialized JSON output"
-    , setopt_json
-  );
+  command_option(&program, "-j", "--json", "generate a serialized JSON output",
+                 setopt_json);
 
   command_parse(&program, argc, argv);
 
-  for (int i = 0; i < program.argc; i++) case_lower(program.argv[i]);
+  for (int i = 0; i < program.argc; i++)
+    case_lower(program.argv[i]);
 
   // set color theme
-  cc_color_t fg_color_highlight = opt_color
-    ? CC_FG_DARK_CYAN
-    : CC_FG_NONE;
-  cc_color_t fg_color_text = opt_color
-    ? CC_FG_DARK_GRAY
-    : CC_FG_NONE;
+  cc_color_t fg_color_highlight = opt_color ? CC_FG_DARK_CYAN : CC_FG_NONE;
+  cc_color_t fg_color_text = opt_color ? CC_FG_DARK_GRAY : CC_FG_NONE;
 
   char *html = wiki_html_cache();
   if (NULL == html) {
@@ -226,7 +201,7 @@ main(int argc, char *argv[]) {
   printf("\n");
 
   while ((node = list_iterator_next(it))) {
-    wiki_package_t *pkg = (wiki_package_t *) node->val;
+    wiki_package_t *pkg = (wiki_package_t *)node->val;
     if (matches(program.argc, program.argv, pkg)) {
       if (opt_json) {
         add_package_to_json(pkg, json_list);

--- a/src/clib-update.c
+++ b/src/clib-update.c
@@ -5,23 +5,23 @@
 // MIT licensed
 //
 
-#include <curl/curl.h>
-#include <stdio.h>
-#include <string.h>
-#include <stdlib.h>
-#include <limits.h>
-#include <libgen.h>
-#include "fs/fs.h"
 #include "commander/commander.h"
-#include "common/clib-package.h"
 #include "common/clib-cache.h"
+#include "common/clib-package.h"
+#include "debug/debug.h"
+#include "fs/fs.h"
 #include "http-get/http-get.h"
 #include "logger/logger.h"
-#include "debug/debug.h"
 #include "parson/parson.h"
 #include "str-concat/str-concat.h"
 #include "str-replace/str-replace.h"
 #include "version.h"
+#include <curl/curl.h>
+#include <libgen.h>
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 #define CLIB_PACKAGE_CACHE_TIME 30 * 24 * 60 * 60
 
@@ -32,14 +32,15 @@
 #define MAX_THREADS 12
 #endif
 
-#if defined(_WIN32) || defined(WIN32) || defined(__MINGW32__) || defined(__MINGW64__) || defined(__CYGWIN__)
+#if defined(_WIN32) || defined(WIN32) || defined(__MINGW32__) ||               \
+    defined(__MINGW64__) || defined(__CYGWIN__)
 #define setenv(k, v, _) _putenv_s(k, v)
 #define realpath(a, b) _fullpath(a, b, strlen(a))
 #endif
 
 extern CURLSH *clib_package_curl_share;
 
-debug_t debugger = { 0 };
+debug_t debugger = {0};
 
 struct options {
   const char *dir;
@@ -52,54 +53,44 @@ struct options {
 #endif
 };
 
-static struct options opts = { 0 };
+static struct options opts = {0};
 
-static const char *manifest_names[] = {
-  "clib.json",
-  "package.json",
-  NULL
-};
+static const char *manifest_names[] = {"clib.json", "package.json", NULL};
 
-static clib_package_opts_t package_opts = { 0 };
+static clib_package_opts_t package_opts = {0};
 static clib_package_t *root_package = NULL;
 
 /**
  * Option setters.
  */
 
-static void
-setopt_dir(command_t *self) {
-  opts.dir = (char *) self->arg;
+static void setopt_dir(command_t *self) {
+  opts.dir = (char *)self->arg;
   debug(&debugger, "set dir: %s", opts.dir);
 }
 
-static void
-setopt_prefix(command_t *self) {
-  opts.prefix = (char *) self->arg;
+static void setopt_prefix(command_t *self) {
+  opts.prefix = (char *)self->arg;
   debug(&debugger, "set prefix: %s", opts.prefix);
 }
 
-static void
-setopt_token(command_t *self) {
-  opts.token = (char *) self->arg;
+static void setopt_token(command_t *self) {
+  opts.token = (char *)self->arg;
   debug(&debugger, "set token: %s", opts.token);
 }
 
-static void
-setopt_quiet(command_t *self) {
+static void setopt_quiet(command_t *self) {
   opts.verbose = 0;
   debug(&debugger, "set quiet flag");
 }
 
-static void
-setopt_dev(command_t *self) {
+static void setopt_dev(command_t *self) {
   opts.dev = 1;
   debug(&debugger, "set development flag");
 }
 
 #ifdef HAVE_PTHREADS
-static void
-setopt_concurrency(command_t *self) {
+static void setopt_concurrency(command_t *self) {
   if (self->arg) {
     opts.concurrency = atol(self->arg);
     debug(&debugger, "set concurrency: %lu", opts.concurrency);
@@ -107,8 +98,7 @@ setopt_concurrency(command_t *self) {
 }
 #endif
 
-static int
-install_local_packages_with_package_name(const char *file) {
+static int install_local_packages_with_package_name(const char *file) {
   if (-1 == fs_exists(file)) {
     logger_error("error", "Missing clib.json or package.json");
     return 1;
@@ -116,22 +106,25 @@ install_local_packages_with_package_name(const char *file) {
 
   debug(&debugger, "reading local clib.json or package.json");
   char *json = fs_read(file);
-  if (NULL == json) return 1;
-
+  if (NULL == json)
+    return 1;
 
   clib_package_t *pkg = clib_package_new(json, opts.verbose);
-  if (NULL == pkg) goto e1;
+  if (NULL == pkg)
+    goto e1;
 
   if (pkg->prefix) {
     setenv("PREFIX", pkg->prefix, 1);
   }
 
   int rc = clib_package_install_dependencies(pkg, opts.dir, opts.verbose);
-  if (-1 == rc) goto e2;
+  if (-1 == rc)
+    goto e2;
 
   if (opts.dev) {
     rc = clib_package_install_development(pkg, opts.dir, opts.verbose);
-    if (-1 == rc) goto e2;
+    if (-1 == rc)
+      goto e2;
   }
 
   free(json);
@@ -148,8 +141,7 @@ e1:
 /**
  * Install dependency packages at `pwd`.
  */
-static int
-install_local_packages() {
+static int install_local_packages() {
   const char *name = NULL;
   unsigned int i = 0;
   int rc = 0;
@@ -162,16 +154,18 @@ install_local_packages() {
   return rc;
 }
 
-static int
-write_dependency_with_package_name(clib_package_t *pkg, char* prefix, const char *file) {
+static int write_dependency_with_package_name(clib_package_t *pkg, char *prefix,
+                                              const char *file) {
   JSON_Value *packageJson = json_parse_file(file);
   JSON_Object *packageJsonObject = json_object(packageJson);
   JSON_Value *newDepSectionValue = NULL;
 
-  if (NULL == packageJson || NULL == packageJsonObject) return 1;
+  if (NULL == packageJson || NULL == packageJsonObject)
+    return 1;
 
   // If the dependency section doesn't exist then create it
-  JSON_Object *depSection = json_object_dotget_object(packageJsonObject, prefix);
+  JSON_Object *depSection =
+      json_object_dotget_object(packageJsonObject, prefix);
   if (NULL == depSection) {
     newDepSectionValue = json_value_init_object();
     depSection = json_value_get_object(newDepSectionValue);
@@ -191,9 +185,8 @@ write_dependency_with_package_name(clib_package_t *pkg, char* prefix, const char
  * Create and install a package from `slug`.
  */
 
-static int
-install_package(const char *slug) {
-  clib_package_t *pkg  = NULL;
+static int install_package(const char *slug) {
+  clib_package_t *pkg = NULL;
   int rc;
 
 #ifdef PATH_MAX
@@ -230,14 +223,11 @@ install_package(const char *slug) {
 
   if (0 == fs_exists(slug)) {
     fs_stats *stats = fs_stat(slug);
-    if (
-      NULL != stats &&
-      (S_IFREG == (stats->st_mode & S_IFMT)
+    if (NULL != stats && (S_IFREG == (stats->st_mode & S_IFMT)
 #if defined(__unix__) || defined(__linux__) || defined(_POSIX_VERSION)
-      || S_IFLNK == (stats->st_mode & S_IFMT)
+                          || S_IFLNK == (stats->st_mode & S_IFMT)
 #endif
-      )
-    ) {
+                              )) {
       free(stats);
       return install_local_packages_with_package_name(slug);
     }
@@ -251,7 +241,8 @@ install_package(const char *slug) {
     pkg = clib_package_new_from_slug(slug, opts.verbose);
   }
 
-  if (NULL == pkg) return -1;
+  if (NULL == pkg)
+    return -1;
 
   if (root_package && root_package->prefix) {
     package_opts.prefix = root_package->prefix;
@@ -283,11 +274,11 @@ cleanup:
  * Install the given `pkgs`.
  */
 
-static int
-install_packages(int n, char *pkgs[]) {
+static int install_packages(int n, char *pkgs[]) {
   for (int i = 0; i < n; i++) {
     debug(&debugger, "install %s (%d)", pkgs[i], i);
-    if (-1 == install_package(pkgs[i])) return 1;
+    if (-1 == install_package(pkgs[i]))
+      return 1;
   }
   return 0;
 }
@@ -296,8 +287,7 @@ install_packages(int n, char *pkgs[]) {
  * Entry point.
  */
 
-int
-main(int argc, char *argv[]) {
+int main(int argc, char *argv[]) {
 #ifdef _WIN32
   opts.dir = ".\\deps";
 #else
@@ -316,51 +306,32 @@ main(int argc, char *argv[]) {
 
   debug_init(&debugger, "clib-update");
 
-  //30 days expiration
+  // 30 days expiration
   clib_cache_init(CLIB_PACKAGE_CACHE_TIME);
 
   command_t program;
 
-  command_init(&program
-    , "clib-update"
-    , CLIB_VERSION);
+  command_init(&program, "clib-update", CLIB_VERSION);
 
   program.usage = "[options] [name ...]";
 
-  command_option(&program
-    , "-o"
-    , "--out <dir>"
-    , "change the output directory [deps]"
-    , setopt_dir);
-  command_option(&program
-    , "-P"
-    , "--prefix <dir>"
-    , "change the prefix directory (usually '/usr/local')"
-    , setopt_prefix);
-  command_option(&program
-    , "-q"
-    , "--quiet"
-    , "disable verbose output"
-    , setopt_quiet);
-  command_option(&program
-    , "-d"
-    , "--dev"
-    , "install development dependencies"
-    , setopt_dev);
-  command_option(&program
-      , "-t"
-      , "--token <token>"
-      , "Access token used to read private content"
-      , setopt_token);
+  command_option(&program, "-o", "--out <dir>",
+                 "change the output directory [deps]", setopt_dir);
+  command_option(&program, "-P", "--prefix <dir>",
+                 "change the prefix directory (usually '/usr/local')",
+                 setopt_prefix);
+  command_option(&program, "-q", "--quiet", "disable verbose output",
+                 setopt_quiet);
+  command_option(&program, "-d", "--dev", "install development dependencies",
+                 setopt_dev);
+  command_option(&program, "-t", "--token <token>",
+                 "Access token used to read private content", setopt_token);
 #ifdef HAVE_PTHREADS
-  command_option(&program,
-     "-C",
-     "--concurrency <number>",
-     "Set concurrency (default: " S(MAX_THREADS) ")",
-     setopt_concurrency);
+  command_option(&program, "-C", "--concurrency <number>",
+                 "Set concurrency (default: " S(MAX_THREADS) ")",
+                 setopt_concurrency);
 #endif
   command_parse(&program, argc, argv);
-
 
   debug(&debugger, "%d arguments", program.argc);
 
@@ -374,8 +345,8 @@ main(int argc, char *argv[]) {
     realpath(opts.prefix, prefix);
     unsigned long int size = strlen(prefix) + 1;
     opts.prefix = malloc(size);
-    memset((void *) opts.prefix, 0, size);
-    memcpy((void *) opts.prefix, prefix, size);
+    memset((void *)opts.prefix, 0, size);
+    memcpy((void *)opts.prefix, prefix, size);
   }
 
   clib_cache_init(CLIB_PACKAGE_CACHE_TIME);
@@ -399,9 +370,8 @@ main(int argc, char *argv[]) {
 
   setenv("CLIB_FORCE", "1", 1);
 
-  int code = 0 == program.argc
-    ? install_local_packages()
-    : install_packages(program.argc, program.argv);
+  int code = 0 == program.argc ? install_local_packages()
+                               : install_packages(program.argc, program.argv);
 
   curl_global_cleanup();
   clib_package_cleanup();

--- a/src/clib-upgrade.c
+++ b/src/clib-upgrade.c
@@ -5,25 +5,25 @@
 // MIT licensed
 //
 
-#include <curl/curl.h>
-#include <stdio.h>
-#include <string.h>
-#include <stdlib.h>
-#include <limits.h>
-#include <libgen.h>
-#include <asprintf/asprintf.h>
-#include "fs/fs.h"
 #include "commander/commander.h"
-#include "common/clib-package.h"
 #include "common/clib-cache.h"
+#include "common/clib-package.h"
+#include "debug/debug.h"
+#include "fs/fs.h"
 #include "http-get/http-get.h"
 #include "logger/logger.h"
-#include "debug/debug.h"
 #include "parson/parson.h"
-#include "tempdir/tempdir.h"
 #include "str-concat/str-concat.h"
 #include "str-replace/str-replace.h"
+#include "tempdir/tempdir.h"
 #include "version.h"
+#include <asprintf/asprintf.h>
+#include <curl/curl.h>
+#include <libgen.h>
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 #define CLIB_PACKAGE_CACHE_TIME 30 * 24 * 60 * 60
 
@@ -34,14 +34,15 @@
 #define MAX_THREADS 16
 #endif
 
-#if defined(_WIN32) || defined(WIN32) || defined(__MINGW32__) || defined(__MINGW64__) || defined(__CYGWIN__)
+#if defined(_WIN32) || defined(WIN32) || defined(__MINGW32__) ||               \
+    defined(__MINGW64__) || defined(__CYGWIN__)
 #define setenv(k, v, _) _putenv_s(k, v)
 #define realpath(a, b) _fullpath(a, b, strlen(a))
 #endif
 
 extern CURLSH *clib_package_curl_share;
 
-debug_t debugger = { 0 };
+debug_t debugger = {0};
 
 struct options {
   char *prefix;
@@ -56,60 +57,49 @@ struct options {
 #endif
 };
 
-static struct options opts = { 0 };
+static struct options opts = {0};
 
-static const char *manifest_names[] = {
-  "clib.json",
-  "package.json",
-  NULL
-};
+static const char *manifest_names[] = {"clib.json", "package.json", NULL};
 
-static clib_package_opts_t package_opts = { 0 };
+static clib_package_opts_t package_opts = {0};
 static clib_package_t *root_package = NULL;
 
 /**
  * Option setters.
  */
 
-static void
-setopt_slug(command_t *self) {
-  opts.slug = (char *) self->arg;
+static void setopt_slug(command_t *self) {
+  opts.slug = (char *)self->arg;
   debug(&debugger, "set slug: %s", opts.slug);
 }
 
-static void
-setopt_tag(command_t *self) {
-  opts.tag = (char *) self->arg;
+static void setopt_tag(command_t *self) {
+  opts.tag = (char *)self->arg;
   debug(&debugger, "set tag: %s", opts.tag);
 }
 
-static void
-setopt_prefix(command_t *self) {
-  opts.prefix = (char *) self->arg;
+static void setopt_prefix(command_t *self) {
+  opts.prefix = (char *)self->arg;
   debug(&debugger, "set prefix: %s", opts.prefix);
 }
 
-static void
-setopt_token(command_t *self) {
-  opts.token = (char *) self->arg;
+static void setopt_token(command_t *self) {
+  opts.token = (char *)self->arg;
   debug(&debugger, "set token: %s", opts.token);
 }
 
-static void
-setopt_quiet(command_t *self) {
+static void setopt_quiet(command_t *self) {
   opts.verbose = 0;
   debug(&debugger, "set quiet flag");
 }
 
-static void
-setopt_force(command_t *self) {
+static void setopt_force(command_t *self) {
   opts.force = 1;
   debug(&debugger, "set force flag");
 }
 
 #ifdef HAVE_PTHREADS
-static void
-setopt_concurrency(command_t *self) {
+static void setopt_concurrency(command_t *self) {
   if (self->arg) {
     opts.concurrency = atol(self->arg);
     debug(&debugger, "set concurrency: %lu", opts.concurrency);
@@ -121,9 +111,8 @@ setopt_concurrency(command_t *self) {
  * Create and install a package from `slug`.
  */
 
-static int
-install_package(const char *slug) {
-  clib_package_t *pkg  = NULL;
+static int install_package(const char *slug) {
+  clib_package_t *pkg = NULL;
   int rc;
 
   if (!root_package) {
@@ -152,7 +141,8 @@ install_package(const char *slug) {
     pkg = clib_package_new_from_slug(slug, opts.verbose);
   }
 
-  if (NULL == pkg) return -1;
+  if (NULL == pkg)
+    return -1;
 
   if (root_package && root_package->prefix) {
     package_opts.prefix = root_package->prefix;
@@ -188,64 +178,44 @@ cleanup:
  * Entry point.
  */
 
-int
-main(int argc, char *argv[]) {
+int main(int argc, char *argv[]) {
   opts.verbose = 1;
 
   long path_max = 4096;
 
   debug_init(&debugger, "clib-upgrade");
 
-  //30 days expiration
+  // 30 days expiration
   clib_cache_init(CLIB_PACKAGE_CACHE_TIME);
 
   command_t program;
 
-  command_init(&program
-    , "clib-upgrade"
-    , CLIB_VERSION);
+  command_init(&program, "clib-upgrade", CLIB_VERSION);
 
   program.usage = "[options] [name ...]";
 
-  command_option(&program
-    , "-P"
-    , "--prefix <dir>"
-    , "change the prefix directory (usually '/usr/local')"
-    , setopt_prefix);
-  command_option(&program
-    , "-q"
-    , "--quiet"
-    , "disable verbose output"
-    , setopt_quiet);
-  command_option(&program
-      , "-f"
-      , "--force"
-      , "force the action of something, like overwriting a file"
-      , setopt_force);
-  command_option(&program
-      , "-t"
-      , "--token <token>"
-      , "Access token used to read private content"
-      , setopt_token);
-  command_option(&program
-      , "-S"
-      , "--slug <slug>"
-      , "The slug where the clib project lives (usually 'clibs/clib')"
-      , setopt_slug);
-  command_option(&program
-      , "-T"
-      , "--tag <tag>"
-      , "The tag to upgrade to (usually it is the latest)"
-      , setopt_token);
+  command_option(&program, "-P", "--prefix <dir>",
+                 "change the prefix directory (usually '/usr/local')",
+                 setopt_prefix);
+  command_option(&program, "-q", "--quiet", "disable verbose output",
+                 setopt_quiet);
+  command_option(&program, "-f", "--force",
+                 "force the action of something, like overwriting a file",
+                 setopt_force);
+  command_option(&program, "-t", "--token <token>",
+                 "Access token used to read private content", setopt_token);
+  command_option(&program, "-S", "--slug <slug>",
+                 "The slug where the clib project lives (usually 'clibs/clib')",
+                 setopt_slug);
+  command_option(&program, "-T", "--tag <tag>",
+                 "The tag to upgrade to (usually it is the latest)",
+                 setopt_token);
 #ifdef HAVE_PTHREADS
-  command_option(&program,
-     "-C",
-     "--concurrency <number>",
-     "Set concurrency (default: " S(MAX_THREADS) ")",
-     setopt_concurrency);
+  command_option(&program, "-C", "--concurrency <number>",
+                 "Set concurrency (default: " S(MAX_THREADS) ")",
+                 setopt_concurrency);
 #endif
   command_parse(&program, argc, argv);
-
 
   debug(&debugger, "%d arguments", program.argc);
 
@@ -259,8 +229,8 @@ main(int argc, char *argv[]) {
     realpath(opts.prefix, prefix);
     unsigned long int size = strlen(prefix) + 1;
     opts.prefix = malloc(size);
-    memset((void *) opts.prefix, 0, size);
-    memcpy((void *) opts.prefix, prefix, size);
+    memset((void *)opts.prefix, 0, size);
+    memcpy((void *)opts.prefix, prefix, size);
   }
 
   clib_cache_init(CLIB_PACKAGE_CACHE_TIME);

--- a/src/clib.c
+++ b/src/clib.c
@@ -5,18 +5,19 @@
 // MIT licensed
 //
 
-#include <stdio.h>
-#include <string.h>
-#include <stdlib.h>
-#include "trim/trim.h"
 #include "asprintf/asprintf.h"
-#include "which/which.h"
+#include "debug/debug.h"
 #include "str-flatten/str-flatten.h"
 #include "strdup/strdup.h"
-#include "debug/debug.h"
+#include "trim/trim.h"
 #include "version.h"
+#include "which/which.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
-#if defined(_WIN32) || defined(WIN32) || defined(__MINGW32__) || defined(__MINGW64__) || defined(__CYGWIN__)
+#if defined(_WIN32) || defined(WIN32) || defined(__MINGW32__) ||               \
+    defined(__MINGW64__) || defined(__CYGWIN__)
 #define setenv(k, v, _) _putenv_s(k, v)
 #define realpath(a, b) _fullpath(a, b, strlen(a))
 #endif
@@ -24,33 +25,34 @@
 debug_t debugger;
 
 static const char *usage =
-  "\n"
-  "  clib <command> [options]\n"
-  "\n"
-  "  Options:\n"
-  "\n"
-  "    -h, --help     Output this message\n"
-  "    -V, --version  Output version information\n"
-  "\n"
-  "  Commands:\n"
-  "\n"
-  "    init                 Start a new project\n"
-  "    i, install [name...] Install one or more packages\n"
-  "    up, update [name...] Update one or more packages\n"
-  "    upgrade [version]    Upgrade clib to a specified or latest version\n"
-  "    configure [name...]  Configure one or more packages\n"
-  "    build [name...]      Build one or more packages\n"
-  "    search [query]       Search for packages\n"
-  "    help <cmd>           Display help for cmd\n"
-  "";
+    "\n"
+    "  clib <command> [options]\n"
+    "\n"
+    "  Options:\n"
+    "\n"
+    "    -h, --help     Output this message\n"
+    "    -V, --version  Output version information\n"
+    "\n"
+    "  Commands:\n"
+    "\n"
+    "    init                 Start a new project\n"
+    "    i, install [name...] Install one or more packages\n"
+    "    up, update [name...] Update one or more packages\n"
+    "    upgrade [version]    Upgrade clib to a specified or latest version\n"
+    "    configure [name...]  Configure one or more packages\n"
+    "    build [name...]      Build one or more packages\n"
+    "    search [query]       Search for packages\n"
+    "    help <cmd>           Display help for cmd\n"
+    "";
 
-#define format(...) ({                               \
-  if (-1 == asprintf(__VA_ARGS__)) {                 \
-    rc = 1;                                          \
-    fprintf(stderr, "Memory allocation failure\n");  \
-    goto cleanup;                                    \
-  }                                                  \
-})
+#define format(...)                                                            \
+  ({                                                                           \
+    if (-1 == asprintf(__VA_ARGS__)) {                                         \
+      rc = 1;                                                                  \
+      fprintf(stderr, "Memory allocation failure\n");                          \
+      goto cleanup;                                                            \
+    }                                                                          \
+  })
 
 int main(int argc, const char **argv) {
 
@@ -64,7 +66,8 @@ int main(int argc, const char **argv) {
   debug_init(&debugger, "clib");
 
   // usage
-  if (NULL == argv[1] || 0 == strncmp(argv[1], "-h", 2) || 0 == strncmp(argv[1], "--help", 6)) {
+  if (NULL == argv[1] || 0 == strncmp(argv[1], "-h", 2) ||
+      0 == strncmp(argv[1], "--help", 6)) {
     printf("%s\n", usage);
     return 0;
   }
@@ -131,7 +134,8 @@ int main(int argc, const char **argv) {
 
 #ifdef _WIN32
   for (char *p = bin; *p; p++)
-    if (*p == '/') *p = '\\';
+    if (*p == '/')
+      *p = '\\';
 #endif
 
   if (args) {
@@ -144,7 +148,8 @@ int main(int argc, const char **argv) {
 
   rc = system(command_with_args);
   debug(&debugger, "returned %d", rc);
-  if (rc > 255) rc = 1;
+  if (rc > 255)
+    rc = 1;
 
 cleanup:
   free(cmd);

--- a/src/common/clib-cache.c
+++ b/src/common/clib-cache.c
@@ -5,29 +5,29 @@
 // MIT licensed
 //
 
+#include "clib-cache.h"
+#include "copy/copy.h"
+#include "fs/fs.h"
+#include "rimraf/rimraf.h"
+#include <limits.h>
+#include <mkdirp/mkdirp.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <limits.h>
 #include <unistd.h>
-#include <mkdirp/mkdirp.h>
-#include "rimraf/rimraf.h"
-#include "fs/fs.h"
-#include "copy/copy.h"
-#include "clib-cache.h"
 
+#define GET_PKG_CACHE(a, n, v)                                                 \
+  char pkg_cache[BUFSIZ];                                                      \
+  package_cache_path(pkg_cache, a, n, v);
 
-#define GET_PKG_CACHE(a, n, v) char pkg_cache[BUFSIZ]; \
-                      package_cache_path(pkg_cache, a, n, v);
-
-#define GET_JSON_CACHE(a, n, v) char json_cache[BUFSIZ]; \
-                  json_cache_path(json_cache, a, n, v);
+#define GET_JSON_CACHE(a, n, v)                                                \
+  char json_cache[BUFSIZ];                                                     \
+  json_cache_path(json_cache, a, n, v);
 
 #ifdef _WIN32
 #define BASE_DIR getenv("AppData")
 #else
 #define BASE_DIR getenv("HOME")
 #endif
-
 
 #define BASE_CACHE_PATTERN "%s/.cache/clib"
 #define PKG_CACHE_PATTERN "%s/%s_%s_%s"
@@ -39,163 +39,143 @@ static char search_cache[BUFSIZ];
 static char json_cache_dir[BUFSIZ];
 static time_t expiration;
 
-
-static void json_cache_path(char *pkg_cache, char *author, char *name, char *version)
-{
-    sprintf(pkg_cache, JSON_CACHE_PATTERN, json_cache_dir, author, name, version);
+static void json_cache_path(char *pkg_cache, char *author, char *name,
+                            char *version) {
+  sprintf(pkg_cache, JSON_CACHE_PATTERN, json_cache_dir, author, name, version);
 }
 
-static void package_cache_path(char *json_cache, char *author, char *name, char *version)
-{
-    sprintf(json_cache, PKG_CACHE_PATTERN, package_cache_dir, author, name, version);
+static void package_cache_path(char *json_cache, char *author, char *name,
+                               char *version) {
+  sprintf(json_cache, PKG_CACHE_PATTERN, package_cache_dir, author, name,
+          version);
 }
 
-const char *clib_cache_dir(void)
-{
-    return package_cache_dir;
+const char *clib_cache_dir(void) { return package_cache_dir; }
+
+static int check_dir(char *dir) {
+  if (0 != (fs_exists(dir))) {
+    return mkdirp(dir, 0700);
+  }
+  return 0;
 }
 
-static int check_dir(char *dir)
-{
-    if (0 != (fs_exists(dir))) {
-        return mkdirp(dir, 0700);
-    }
-    return 0;
+int clib_cache_init(time_t exp) {
+  expiration = exp;
+
+  sprintf(package_cache_dir, BASE_CACHE_PATTERN "/packages", BASE_DIR);
+  sprintf(json_cache_dir, BASE_CACHE_PATTERN "/json", BASE_DIR);
+  sprintf(search_cache, BASE_CACHE_PATTERN "/search.html", BASE_DIR);
+
+  if (0 != check_dir(package_cache_dir)) {
+    return -1;
+  }
+  if (0 != check_dir(json_cache_dir)) {
+    return -1;
+  }
+
+  return 0;
 }
 
-int clib_cache_init(time_t exp)
-{
-    expiration = exp;
+static int is_expired(char *cache) {
+  fs_stats *stat = fs_stat(cache);
 
-    sprintf(package_cache_dir, BASE_CACHE_PATTERN"/packages", BASE_DIR);
-    sprintf(json_cache_dir, BASE_CACHE_PATTERN"/json", BASE_DIR);
-    sprintf(search_cache, BASE_CACHE_PATTERN"/search.html", BASE_DIR);
+  if (!stat) {
+    return -1;
+  }
 
-    if (0 != check_dir(package_cache_dir)) {
-        return -1;
-    }
-    if (0 != check_dir(json_cache_dir)) {
-        return -1;
-    }
+  time_t modified = stat->st_mtime;
+  time_t now = time(NULL);
+  free(stat);
 
-    return 0;
+  return now - modified >= expiration;
 }
 
-static int is_expired(char *cache)
-{
-    fs_stats *stat = fs_stat(cache);
+int clib_cache_has_json(char *author, char *name, char *version) {
+  GET_JSON_CACHE(author, name, version);
 
-    if (!stat) {
-        return -1;
-    }
-
-    time_t modified = stat->st_mtime;
-    time_t now = time(NULL);
-    free(stat);
-
-    return now - modified >= expiration;
+  return 0 == fs_exists(json_cache) && !is_expired(json_cache);
 }
 
-int clib_cache_has_json(char *author, char *name, char *version)
-{
-    GET_JSON_CACHE(author, name, version);
+char *clib_cache_read_json(char *author, char *name, char *version) {
+  GET_JSON_CACHE(author, name, version);
 
-    return 0 == fs_exists(json_cache) && !is_expired(json_cache);
+  if (is_expired(json_cache)) {
+    return NULL;
+  }
+
+  return fs_read(json_cache);
 }
 
-char *clib_cache_read_json(char *author, char *name, char *version)
-{
-    GET_JSON_CACHE(author, name, version);
+int clib_cache_save_json(char *author, char *name, char *version,
+                         char *content) {
+  GET_JSON_CACHE(author, name, version);
 
-    if (is_expired(json_cache)) {
-        return NULL;
-    }
-
-    return fs_read(json_cache);
+  return fs_write(json_cache, content);
 }
 
-int clib_cache_save_json(char *author, char *name, char *version, char *content)
-{
-    GET_JSON_CACHE(author, name, version);
+int clib_cache_delete_json(char *author, char *name, char *version) {
+  GET_JSON_CACHE(author, name, version);
 
-    return fs_write(json_cache, content);
+  return unlink(json_cache);
 }
 
-int clib_cache_delete_json(char *author, char *name, char *version)
-{
-    GET_JSON_CACHE(author, name, version);
+int clib_cache_has_search(void) { return 0 == fs_exists(search_cache); }
 
-    return unlink(json_cache);
+char *clib_cache_read_search(void) {
+  if (!clib_cache_has_search()) {
+    return NULL;
+  }
+  return fs_read(search_cache);
 }
 
-int clib_cache_has_search(void)
-{
-    return 0 == fs_exists(search_cache);
+int clib_cache_save_search(char *content) {
+  return fs_write(search_cache, content);
 }
 
-char *clib_cache_read_search(void)
-{
-    if (!clib_cache_has_search()) {
-        return NULL;
-    }
-    return fs_read(search_cache);
+int clib_cache_delete_search(void) { return unlink(search_cache); }
+
+int clib_cache_has_package(char *author, char *name, char *version) {
+  GET_PKG_CACHE(author, name, version);
+
+  return 0 == fs_exists(pkg_cache) && !is_expired(pkg_cache);
 }
 
-int clib_cache_save_search(char *content)
-{
-    return fs_write(search_cache, content);
+int clib_cache_is_expired_package(char *author, char *name, char *version) {
+  GET_PKG_CACHE(author, name, version);
+
+  return is_expired(pkg_cache);
 }
 
-int clib_cache_delete_search(void)
-{
-    return unlink(search_cache);
+int clib_cache_save_package(char *author, char *name, char *version,
+                            char *pkg_dir) {
+  GET_PKG_CACHE(author, name, version);
+
+  if (0 == fs_exists(pkg_cache)) {
+    rimraf(pkg_cache);
+  }
+
+  return copy_dir(pkg_dir, pkg_cache);
 }
 
-int clib_cache_has_package(char *author, char *name, char *version)
-{
-    GET_PKG_CACHE(author, name, version);
+int clib_cache_load_package(char *author, char *name, char *version,
+                            char *target_dir) {
+  GET_PKG_CACHE(author, name, version);
 
-    return 0 == fs_exists(pkg_cache) && !is_expired(pkg_cache);
+  if (-1 == fs_exists(pkg_cache)) {
+    return -1;
+  }
+
+  if (is_expired(pkg_cache)) {
+    rimraf(pkg_cache);
+
+    return -2;
+  }
+
+  return copy_dir(pkg_cache, target_dir);
 }
 
-int clib_cache_is_expired_package(char *author, char *name, char *version)
-{
-    GET_PKG_CACHE(author, name, version);
+int clib_cache_delete_package(char *author, char *name, char *version) {
+  GET_PKG_CACHE(author, name, version);
 
-    return is_expired(pkg_cache);
-}
-
-int clib_cache_save_package(char *author, char *name, char *version, char *pkg_dir)
-{
-    GET_PKG_CACHE(author, name, version);
-
-    if (0 == fs_exists(pkg_cache)) {
-        rimraf(pkg_cache);
-    }
-
-    return copy_dir(pkg_dir, pkg_cache);
-}
-
-int clib_cache_load_package(char *author, char *name, char *version, char *target_dir)
-{
-    GET_PKG_CACHE(author, name, version);
-
-    if (-1 == fs_exists(pkg_cache)) {
-        return -1;
-    }
-
-    if (is_expired(pkg_cache)) {
-        rimraf(pkg_cache);
-
-        return -2;
-    }
-
-    return copy_dir(pkg_cache, target_dir);
-}
-
-int clib_cache_delete_package(char *author, char *name, char *version)
-{
-    GET_PKG_CACHE(author, name, version);
-
-    return rimraf(pkg_cache);
+  return rimraf(pkg_cache);
 }

--- a/src/common/clib-cache.h
+++ b/src/common/clib-cache.h
@@ -8,11 +8,9 @@
 #ifndef CLIB_CACHE_H
 #define CLIB_CACHE_H
 
-
 #include <stdbool.h>
 #include <stdint.h>
 #include <time.h>
-
 
 /**
  * Internal setup, creates the base cache dir if necessary
@@ -36,14 +34,16 @@ const char *clib_cache_dir(void);
 int clib_cache_has_json(char *author, char *name, char *version);
 
 /**
- * @return The content of the cached package.json, or NULL on error, if not found, or expired
+ * @return The content of the cached package.json, or NULL on error, if not
+ * found, or expired
  */
 char *clib_cache_read_json(char *author, char *name, char *version);
 
 /**
  * @return Number of written bytes, or -1 on error
  */
-int clib_cache_save_json(char *author, char *name, char *version, char *content);
+int clib_cache_save_json(char *author, char *name, char *version,
+                         char *content);
 
 /**
  * @return Number of written bytes, or -1 on error
@@ -56,12 +56,14 @@ int clib_cache_delete_json(char *author, char *name, char *version);
 int clib_cache_has_search(void);
 
 /**
- * @return The content of the search cache, NULL on error, if not found, or expired
+ * @return The content of the search cache, NULL on error, if not found, or
+ * expired
  */
 char *clib_cache_read_search(void);
 
 /**
- * @return Number of written bytes, or -1 on error, or if there is no search cahce
+ * @return Number of written bytes, or -1 on error, or if there is no search
+ * cahce
  */
 int clib_cache_save_search(char *content);
 
@@ -76,8 +78,8 @@ int clib_cache_delete_search(void);
 int clib_cache_has_package(char *author, char *name, char *version);
 
 /**
- * @return 0/1 if the cached package modified date is more or less then the given expiration.
- *         -1 if the package is not cached
+ * @return 0/1 if the cached package modified date is more or less then the
+ * given expiration. -1 if the package is not cached
  */
 int clib_cache_is_expired_package(char *author, char *name, char *version);
 
@@ -87,20 +89,22 @@ int clib_cache_is_expired_package(char *author, char *name, char *version);
  * @return 0 on success, -1 on error, if the package is not found in the cache.
  *         If the cached package is expired, it will be deleted, and -2 returned
  */
-int clib_cache_load_package(char *author, char *name, char *version, char *target_dir);
+int clib_cache_load_package(char *author, char *name, char *version,
+                            char *target_dir);
 
 /**
  * @param pkg_dir The downloaded package (e.g. ./deps/my_package).
- *                If the package was already cached, it will be deleted first, then saved
+ *                If the package was already cached, it will be deleted first,
+ * then saved
  *
  * @return 0 on success, -1 on error
  */
-int clib_cache_save_package(char *author, char *name, char *version, char *pkg_dir);
+int clib_cache_save_package(char *author, char *name, char *version,
+                            char *pkg_dir);
 
 /**
  * @return 0 on success, -1 on error
  */
 int clib_cache_delete_package(char *author, char *name, char *version);
-
 
 #endif

--- a/src/common/clib-package.c
+++ b/src/common/clib-package.c
@@ -6,32 +6,32 @@
 // MIT license
 //
 
-#if defined (__unix__) || (defined (__APPLE__) && defined (__MACH__))
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
 #include <unistd.h>
 #endif
 
-#include <limits.h>
-#include <stdlib.h>
-#include <libgen.h>
-#include <stdarg.h>
-#include <string.h>
-#include <stdio.h>
-#include <curl/curl.h>
 #include "asprintf/asprintf.h"
-#include "tempdir/tempdir.h"
-#include "strdup/strdup.h"
-#include "parson/parson.h"
-#include "substr/substr.h"
-#include "http-get/http-get.h"
-#include "mkdirp/mkdirp.h"
-#include "path-join/path-join.h"
-#include "logger/logger.h"
-#include "parse-repo/parse-repo.h"
-#include "debug/debug.h"
-#include "clib-package.h"
 #include "clib-cache.h"
+#include "clib-package.h"
+#include "debug/debug.h"
 #include "fs/fs.h"
 #include "hash/hash.h"
+#include "http-get/http-get.h"
+#include "logger/logger.h"
+#include "mkdirp/mkdirp.h"
+#include "parse-repo/parse-repo.h"
+#include "parson/parson.h"
+#include "path-join/path-join.h"
+#include "strdup/strdup.h"
+#include "substr/substr.h"
+#include "tempdir/tempdir.h"
+#include <curl/curl.h>
+#include <libgen.h>
+#include <limits.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 #ifdef HAVE_PTHREADS
 #include <pthread.h>
@@ -48,7 +48,8 @@
 #define GITHUB_CONTENT_URL "https://raw.githubusercontent.com/"
 #define GITHUB_CONTENT_URL_WITH_TOKEN "https://%s@raw.githubusercontent.com/"
 
-#if defined(_WIN32) || defined(WIN32) || defined(__MINGW32__) || defined(__MINGW64__) || defined(__CYGWIN__)
+#if defined(_WIN32) || defined(WIN32) || defined(__MINGW32__) ||               \
+    defined(__MINGW64__) || defined(__CYGWIN__)
 #define setenv(k, v, _) _putenv_s(k, v)
 #define realpath(a, b) _fullpath(a, b, strlen(a))
 #endif
@@ -72,70 +73,59 @@ struct clib_package_lock {
   pthread_mutex_t mutex;
 };
 
-static clib_package_lock_t lock = {
-  PTHREAD_MUTEX_INITIALIZER
-};
+static clib_package_lock_t lock = {PTHREAD_MUTEX_INITIALIZER};
 
 #endif
 
 CURLSH *clib_package_curl_share;
 debug_t _debugger;
 
-#define _debug(...) ({                                           \
-  if (!(_debugger.name)) debug_init(&_debugger, "clib-package"); \
-  debug(&_debugger, __VA_ARGS__);                                \
-})
+#define _debug(...)                                                            \
+  ({                                                                           \
+    if (!(_debugger.name))                                                     \
+      debug_init(&_debugger, "clib-package");                                  \
+    debug(&_debugger, __VA_ARGS__);                                            \
+  })
 
-static const char *manifest_names[] = {
-  "clib.json",
-  "package.json",
-  NULL
-};
+static const char *manifest_names[] = {"clib.json", "package.json", NULL};
 
-#define E_FORMAT(...) ({      \
-  rc = asprintf(__VA_ARGS__); \
-  if (-1 == rc) goto cleanup; \
-});
+#define E_FORMAT(...)                                                          \
+  ({                                                                           \
+    rc = asprintf(__VA_ARGS__);                                                \
+    if (-1 == rc)                                                              \
+      goto cleanup;                                                            \
+  });
 
 static clib_package_opts_t opts = {
 #ifdef HAVE_PTHREADS
-  .concurrency = 4,
+    .concurrency = 4,
 #endif
-  .skip_cache = 1,
-  .prefix = 0,
-  .global = 0,
-  .force = 0,
-  .token = 0,
+    .skip_cache = 1,
+    .prefix = 0,
+    .global = 0,
+    .force = 0,
+    .token = 0,
 };
 
 /**
  * Pre-declare prototypes.
  */
 
-static inline char *
-json_object_get_string_safe(JSON_Object *, const char *);
+static inline char *json_object_get_string_safe(JSON_Object *, const char *);
 
-static inline char *
-json_array_get_string_safe(JSON_Array *, int);
+static inline char *json_array_get_string_safe(JSON_Array *, int);
 
-static inline char *
-clib_package_file_url(const char *, const char *);
+static inline char *clib_package_file_url(const char *, const char *);
 
-static inline char *
-clib_package_slug(const char *, const char *, const char *);
+static inline char *clib_package_slug(const char *, const char *, const char *);
 
-static inline char *
-clib_package_repo(const char *, const char *);
+static inline char *clib_package_repo(const char *, const char *);
 
-static inline list_t *
-parse_package_deps(JSON_Object *);
+static inline list_t *parse_package_deps(JSON_Object *);
 
-static inline int
-install_packages(list_t *, const char *, int);
+static inline int install_packages(list_t *, const char *, int);
 
-
-void
-clib_package_set_opts(clib_package_opts_t o) {
+void clib_package_set_opts(clib_package_opts_t o) {
   if (1 == opts.skip_cache && 0 == o.skip_cache) {
     opts.skip_cache = 0;
   } else if (0 == opts.skip_cache && 1 == o.skip_cache) {
@@ -187,10 +177,11 @@ clib_package_set_opts(clib_package_opts_t o) {
  * parent `JSON_Value` without destroying the string.
  */
 
-static inline char *
-json_object_get_string_safe(JSON_Object *obj, const char *key) {
+static inline char *json_object_get_string_safe(JSON_Object *obj,
+                                                const char *key) {
   const char *val = json_object_get_string(obj, key);
-  if (!val) return NULL;
+  if (!val)
+    return NULL;
   return strdup(val);
 }
 
@@ -200,10 +191,10 @@ json_object_get_string_safe(JSON_Object *obj, const char *key) {
  * parent `JSON_Value` without destroying the string.
  */
 
-static inline char *
-json_array_get_string_safe(JSON_Array *array, int index) {
+static inline char *json_array_get_string_safe(JSON_Array *array, int index) {
   const char *val = json_array_get_string(array, index);
-  if (!val) return NULL;
+  if (!val)
+    return NULL;
   return strdup(val);
 }
 
@@ -211,16 +202,13 @@ json_array_get_string_safe(JSON_Array *array, int index) {
  * Build a URL for `file` of the package belonging to `url`
  */
 
-static inline char *
-clib_package_file_url(const char *url, const char *file) {
-  if (!url || !file) return NULL;
+static inline char *clib_package_file_url(const char *url, const char *file) {
+  if (!url || !file)
+    return NULL;
 
-  int size =
-      strlen(url)
-    + 1  // /
-    + strlen(file)
-    + 1  // \0
-    ;
+  int size = strlen(url) + 1    // /
+             + strlen(file) + 1 // \0
+      ;
 
   char *res = malloc(size);
   if (res) {
@@ -234,16 +222,12 @@ clib_package_file_url(const char *url, const char *file) {
  * Build a slug
  */
 
-static inline char *
-clib_package_slug(const char *author, const char *name, const char *version) {
-  int size =
-      strlen(author)
-    + 1 // /
-    + strlen(name)
-    + 1 // @
-    + strlen(version)
-    + 1 // \0
-    ;
+static inline char *clib_package_slug(const char *author, const char *name,
+                                      const char *version) {
+  int size = strlen(author) + 1    // /
+             + strlen(name) + 1    // @
+             + strlen(version) + 1 // \0
+      ;
 
   char *slug = malloc(size);
   if (slug) {
@@ -257,8 +241,8 @@ clib_package_slug(const char *author, const char *name, const char *version) {
  * Load a local package with a manifest.
  */
 
-clib_package_t *
-clib_package_load_from_manifest(const char* manifest, int verbose) {
+clib_package_t *clib_package_load_from_manifest(const char *manifest,
+                                                int verbose) {
   clib_package_t *pkg = NULL;
 
   if (-1 == fs_exists(manifest)) {
@@ -269,11 +253,12 @@ clib_package_load_from_manifest(const char* manifest, int verbose) {
   logger_info("info", "reading local %s", manifest);
 
   char *json = fs_read(manifest);
-  if (NULL == json) goto e1;
+  if (NULL == json)
+    goto e1;
 
   pkg = clib_package_new(json, verbose);
 
- e1:
+e1:
   free(json);
 
   return pkg;
@@ -283,13 +268,12 @@ clib_package_load_from_manifest(const char* manifest, int verbose) {
  * Load a manifest from the current path.
  */
 
-clib_package_t *
-clib_package_load_local_manifest(int verbose) {
-  clib_package_t* pkg = NULL;
+clib_package_t *clib_package_load_local_manifest(int verbose) {
+  clib_package_t *pkg = NULL;
   int i = 0;
 
   do {
-    const char* name = NULL;
+    const char *name = NULL;
     name = manifest_names[i];
     pkg = clib_package_load_from_manifest(name, verbose);
   } while (pkg == NULL && NULL != manifest_names[++i]);
@@ -301,14 +285,10 @@ clib_package_load_local_manifest(int verbose) {
  * Build a repo
  */
 
-static inline char *
-clib_package_repo(const char *author, const char *name) {
-  int size =
-      strlen(author)
-    + 1 // /
-    + strlen(name)
-    + 1 // \0
-    ;
+static inline char *clib_package_repo(const char *author, const char *name) {
+  int size = strlen(author) + 1 // /
+             + strlen(name) + 1 // \0
+      ;
 
   char *repo = malloc(size);
   if (repo) {
@@ -322,12 +302,13 @@ clib_package_repo(const char *author, const char *name) {
  * Parse the dependencies in the given `obj` into a `list_t`
  */
 
-static inline list_t *
-parse_package_deps(JSON_Object *obj) {
+static inline list_t *parse_package_deps(JSON_Object *obj) {
   list_t *list = NULL;
 
-  if (!obj) goto done;
-  if (!(list = list_new())) goto done;
+  if (!obj)
+    goto done;
+  if (!(list = list_new()))
+    goto done;
   list->free = clib_package_dependency_free;
 
   for (unsigned int i = 0; i < json_object_get_count(obj); i++) {
@@ -336,15 +317,20 @@ parse_package_deps(JSON_Object *obj) {
     clib_package_dependency_t *dep = NULL;
     int error = 1;
 
-    if (!(name = json_object_get_name(obj, i))) goto loop_cleanup;
-    if (!(version = json_object_get_string_safe(obj, name))) goto loop_cleanup;
-    if (!(dep = clib_package_dependency_new(name, version))) goto loop_cleanup;
-    if (!(list_rpush(list, list_node_new(dep)))) goto loop_cleanup;
+    if (!(name = json_object_get_name(obj, i)))
+      goto loop_cleanup;
+    if (!(version = json_object_get_string_safe(obj, name)))
+      goto loop_cleanup;
+    if (!(dep = clib_package_dependency_new(name, version)))
+      goto loop_cleanup;
+    if (!(list_rpush(list, list_node_new(dep))))
+      goto loop_cleanup;
 
     error = 0;
 
   loop_cleanup:
-    if (version) free(version);
+    if (version)
+      free(version);
     if (error) {
       list_destroy(list);
       list = NULL;
@@ -356,16 +342,17 @@ done:
   return list;
 }
 
-static inline int
-install_packages(list_t *list, const char *dir, int verbose) {
+static inline int install_packages(list_t *list, const char *dir, int verbose) {
   list_node_t *node = NULL;
   list_iterator_t *iterator = NULL;
   int rc = -1;
 
-  if (!list || !dir) goto cleanup;
+  if (!list || !dir)
+    goto cleanup;
 
   iterator = list_iterator_new(list, LIST_HEAD);
-  if (NULL == iterator) goto cleanup;
+  if (NULL == iterator)
+    goto cleanup;
 
   list_t *freelist = list_new();
 
@@ -375,20 +362,24 @@ install_packages(list_t *list, const char *dir, int verbose) {
     clib_package_t *pkg = NULL;
     int error = 1;
 
-    dep = (clib_package_dependency_t *) node->val;
+    dep = (clib_package_dependency_t *)node->val;
     slug = clib_package_slug(dep->author, dep->name, dep->version);
-    if (NULL == slug) goto loop_cleanup;
+    if (NULL == slug)
+      goto loop_cleanup;
 
     pkg = clib_package_new_from_slug(slug, verbose);
-    if (NULL == pkg) goto loop_cleanup;
+    if (NULL == pkg)
+      goto loop_cleanup;
 
-    if (-1 == clib_package_install(pkg, dir, verbose)) goto loop_cleanup;
+    if (-1 == clib_package_install(pkg, dir, verbose))
+      goto loop_cleanup;
 
     list_rpush(freelist, list_node_new(pkg));
     error = 0;
 
   loop_cleanup:
-    if (slug) free(slug);
+    if (slug)
+      free(slug);
     if (error) {
       list_iterator_destroy(iterator);
       iterator = NULL;
@@ -400,11 +391,13 @@ install_packages(list_t *list, const char *dir, int verbose) {
   rc = 0;
 
 cleanup:
-  if (iterator) list_iterator_destroy(iterator);
+  if (iterator)
+    list_iterator_destroy(iterator);
   iterator = list_iterator_new(freelist, LIST_HEAD);
   while ((node = list_iterator_next(iterator))) {
     clib_package_t *pkg = node->val;
-    if (pkg) clib_package_free(pkg);
+    if (pkg)
+      clib_package_free(pkg);
   }
   list_iterator_destroy(iterator);
   list_destroy(freelist);
@@ -412,35 +405,28 @@ cleanup:
 }
 
 #ifdef HAVE_PTHREADS
-static void
-curl_lock_callback(
-    CURL *handle
-  , curl_lock_data data
-  , curl_lock_access access
-  , void *userptr
-) {
+static void curl_lock_callback(CURL *handle, curl_lock_data data,
+                               curl_lock_access access, void *userptr) {
   pthread_mutex_lock(&lock.mutex);
 }
 
-static void
-curl_unlock_callback(
-    CURL *handle
-  , curl_lock_data data
-  , curl_lock_access access
-  , void *userptr
-) {
+static void curl_unlock_callback(CURL *handle, curl_lock_data data,
+                                 curl_lock_access access, void *userptr) {
   pthread_mutex_unlock(&lock.mutex);
 }
 
-static void
-init_curl_share() {
+static void init_curl_share() {
   if (0 == clib_package_curl_share) {
     pthread_mutex_lock(&lock.mutex);
     clib_package_curl_share = curl_share_init();
-    curl_share_setopt(clib_package_curl_share, CURLSHOPT_SHARE, CURL_LOCK_DATA_CONNECT);
-    curl_share_setopt(clib_package_curl_share, CURLSHOPT_LOCKFUNC, curl_lock_callback);
-    curl_share_setopt(clib_package_curl_share, CURLSHOPT_UNLOCKFUNC, curl_unlock_callback);
-    curl_share_setopt(clib_package_curl_share, CURLOPT_NETRC, CURL_NETRC_OPTIONAL);
+    curl_share_setopt(clib_package_curl_share, CURLSHOPT_SHARE,
+                      CURL_LOCK_DATA_CONNECT);
+    curl_share_setopt(clib_package_curl_share, CURLSHOPT_LOCKFUNC,
+                      curl_lock_callback);
+    curl_share_setopt(clib_package_curl_share, CURLSHOPT_UNLOCKFUNC,
+                      curl_unlock_callback);
+    curl_share_setopt(clib_package_curl_share, CURLOPT_NETRC,
+                      CURL_NETRC_OPTIONAL);
     pthread_mutex_unlock(&lock.mutex);
   }
 }
@@ -450,8 +436,7 @@ init_curl_share() {
  * Create a new clib package from the given `json`
  */
 
-clib_package_t *
-clib_package_new(const char *json, int verbose) {
+clib_package_t *clib_package_new(const char *json, int verbose) {
   clib_package_t *pkg = NULL;
   JSON_Value *root = NULL;
   JSON_Object *json_object = NULL;
@@ -519,7 +504,7 @@ clib_package_new(const char *json, int verbose) {
             pkg->flags = "";
           }
 
-          if (-1 == asprintf(&pkg->flags, "%s %s", pkg->flags, flag)){
+          if (-1 == asprintf(&pkg->flags, "%s %s", pkg->flags, flag)) {
             goto cleanup;
           }
 
@@ -545,10 +530,9 @@ clib_package_new(const char *json, int verbose) {
     pkg->repo_name = parse_repo_name(pkg->repo);
   } else {
     if (verbose) {
-      logger_warn(
-        "warning",
-        "missing repo in clib.json or package.json file for %s",
-        pkg->name);
+      logger_warn("warning",
+                  "missing repo in clib.json or package.json file for %s",
+                  pkg->name);
     }
     pkg->author = NULL;
     pkg->repo_name = NULL;
@@ -561,13 +545,16 @@ clib_package_new(const char *json, int verbose) {
   }
 
   if (src) {
-    if (!(pkg->src = list_new())) goto cleanup;
+    if (!(pkg->src = list_new()))
+      goto cleanup;
     pkg->src->free = free;
     for (unsigned int i = 0; i < json_array_get_count(src); i++) {
       char *file = json_array_get_string_safe(src, i);
       _debug("file: %s", file);
-      if (!file) goto cleanup;
-      if (!(list_rpush(pkg->src, list_node_new(file)))) goto cleanup;
+      if (!file)
+        goto cleanup;
+      if (!(list_rpush(pkg->src, list_node_new(file))))
+        goto cleanup;
     }
   } else {
     _debug("no src files listed in clib.json or package.json file");
@@ -588,14 +575,16 @@ clib_package_new(const char *json, int verbose) {
       goto cleanup;
     }
   } else {
-    _debug("no development dependencies listed in clib.json or package.json file");
+    _debug(
+        "no development dependencies listed in clib.json or package.json file");
     pkg->development = NULL;
   }
 
   error = 0;
 
 cleanup:
-  if (root) json_value_free(root);
+  if (root)
+    json_value_free(root);
   if (error && pkg) {
     clib_package_free(pkg);
     pkg = NULL;
@@ -604,7 +593,8 @@ cleanup:
 }
 
 static clib_package_t *
-clib_package_new_from_slug_with_package_name(const char *slug, int verbose, const char *file) {
+clib_package_new_from_slug_with_package_name(const char *slug, int verbose,
+                                             const char *file) {
   char *author = NULL;
   char *name = NULL;
   char *version = NULL;
@@ -618,13 +608,19 @@ clib_package_new_from_slug_with_package_name(const char *slug, int verbose, cons
   int retries = 3;
 
   // parse chunks
-  if (!slug) goto error;
+  if (!slug)
+    goto error;
   _debug("creating package: %s", slug);
-  if (!(author = parse_repo_owner(slug, DEFAULT_REPO_OWNER))) goto error;
-  if (!(name = parse_repo_name(slug))) goto error;
-  if (!(version = parse_repo_version(slug, DEFAULT_REPO_VERSION))) goto error;
-  if (!(url = clib_package_url(author, name, version))) goto error;
-  if (!(json_url = clib_package_file_url(url, file))) goto error;
+  if (!(author = parse_repo_owner(slug, DEFAULT_REPO_OWNER)))
+    goto error;
+  if (!(name = parse_repo_name(slug)))
+    goto error;
+  if (!(version = parse_repo_version(slug, DEFAULT_REPO_VERSION)))
+    goto error;
+  if (!(url = clib_package_url(author, name, version)))
+    goto error;
+  if (!(json_url = clib_package_file_url(url, file)))
+    goto error;
 
   _debug("author: %s", author);
   _debug("name: %s", name);
@@ -651,9 +647,9 @@ clib_package_new_from_slug_with_package_name(const char *slug, int verbose, cons
     pthread_mutex_unlock(&lock.mutex);
 #endif
   } else {
-download:
+  download:
 #ifdef HAVE_PTHREADS
-      pthread_mutex_unlock(&lock.mutex);
+    pthread_mutex_unlock(&lock.mutex);
 #endif
     if (retries-- <= 0) {
       goto error;
@@ -688,7 +684,8 @@ download:
     pkg = clib_package_new(json, verbose);
   }
 
-  if (!pkg) goto error;
+  if (!pkg)
+    goto error;
 
   // force version number
   if (pkg->version) {
@@ -735,26 +732,21 @@ download:
 
   pkg->url = url;
 
-
 #ifdef HAVE_PTHREADS
-    pthread_mutex_lock(&lock.mutex);
+  pthread_mutex_lock(&lock.mutex);
 #endif
   // cache json
   if (pkg && pkg->author && pkg->name && pkg->version) {
-    if (-1 == clib_cache_save_json(pkg->author, pkg->name, pkg->version, json)) {
-      _debug("failed to cache JSON for: %s/%s@%s"
-        , pkg->author
-        , pkg->name
-        , pkg->version);
+    if (-1 ==
+        clib_cache_save_json(pkg->author, pkg->name, pkg->version, json)) {
+      _debug("failed to cache JSON for: %s/%s@%s", pkg->author, pkg->name,
+             pkg->version);
     } else {
-      _debug("cached: %s/%s@%s"
-        , pkg->author
-        , pkg->name
-        , pkg->version);
+      _debug("cached: %s/%s@%s", pkg->author, pkg->name, pkg->version);
     }
   }
 #ifdef HAVE_PTHREADS
-    pthread_mutex_unlock(&lock.mutex);
+  pthread_mutex_unlock(&lock.mutex);
 #endif
 
   if (res) {
@@ -781,9 +773,12 @@ error:
   free(url);
   free(json_url);
   free(repo);
-  if (!res && json) free(json);
-  if (res) http_get_free(res);
-  if (pkg) clib_package_free(pkg);
+  if (!res && json)
+    free(json);
+  if (res)
+    http_get_free(res);
+  if (pkg)
+    clib_package_free(pkg);
   return NULL;
 }
 
@@ -791,8 +786,7 @@ error:
  * Create a package from the given repo `slug`
  */
 
-clib_package_t *
-clib_package_new_from_slug(const char *slug, int verbose) {
+clib_package_t *clib_package_new_from_slug(const char *slug, int verbose) {
   clib_package_t *package = NULL;
   const char *name = NULL;
   unsigned int i = 0;
@@ -801,7 +795,7 @@ clib_package_new_from_slug(const char *slug, int verbose) {
     name = manifest_names[i];
     package = clib_package_new_from_slug_with_package_name(slug, verbose, name);
     if (NULL != package) {
-      package->filename = (char *) name;
+      package->filename = (char *)name;
     }
   } while (NULL != manifest_names[++i] && NULL == package);
 
@@ -812,17 +806,14 @@ clib_package_new_from_slug(const char *slug, int verbose) {
  * Get a slug for the package `author/name@version`
  */
 
-char *
-clib_package_url(const char *author, const char *name, const char *version) {
-  if (!author || !name || !version) return NULL;
-  int size = strlen(GITHUB_CONTENT_URL)
-    + strlen(author)
-    + 1 // /
-    + strlen(name)
-    + 1 // /
-    + strlen(version)
-    + 1 // \0
-    ;
+char *clib_package_url(const char *author, const char *name,
+                       const char *version) {
+  if (!author || !name || !version)
+    return NULL;
+  int size = strlen(GITHUB_CONTENT_URL) + strlen(author) + 1 // /
+             + strlen(name) + 1                              // /
+             + strlen(version) + 1                           // \0
+      ;
 
   if (0 != opts.token) {
     size += strlen(opts.token);
@@ -833,33 +824,22 @@ clib_package_url(const char *author, const char *name, const char *version) {
   if (slug) {
     memset(slug, '\0', size);
     if (0 != opts.token) {
-      sprintf(slug
-          , GITHUB_CONTENT_URL_WITH_TOKEN "%s/%s/%s"
-          , opts.token
-          , author
-          , name
-          , version);
+      sprintf(slug, GITHUB_CONTENT_URL_WITH_TOKEN "%s/%s/%s", opts.token,
+              author, name, version);
     } else {
-      sprintf(slug
-          , GITHUB_CONTENT_URL "%s/%s/%s"
-          , author
-          , name
-          , version);
+      sprintf(slug, GITHUB_CONTENT_URL "%s/%s/%s", author, name, version);
     }
   }
 
   return slug;
 }
 
-char *
-clib_package_url_from_repo(const char *repo, const char *version) {
-  if (!repo || !version) return NULL;
-  int size = strlen(GITHUB_CONTENT_URL)
-    + strlen(repo)
-    + 1 // /
-    + strlen(version)
-    + 1 // \0
-    ;
+char *clib_package_url_from_repo(const char *repo, const char *version) {
+  if (!repo || !version)
+    return NULL;
+  int size = strlen(GITHUB_CONTENT_URL) + strlen(repo) + 1 // /
+             + strlen(version) + 1                         // \0
+      ;
 
   if (0 != opts.token) {
     size += strlen(opts.token);
@@ -870,16 +850,10 @@ clib_package_url_from_repo(const char *repo, const char *version) {
   if (slug) {
     memset(slug, '\0', size);
     if (0 != opts.token) {
-      sprintf(slug
-          , GITHUB_CONTENT_URL_WITH_TOKEN "%s/%s"
-          , opts.token
-          , repo
-          , version);
+      sprintf(slug, GITHUB_CONTENT_URL_WITH_TOKEN "%s/%s", opts.token, repo,
+              version);
     } else {
-      sprintf(slug
-          , GITHUB_CONTENT_URL "%s/%s"
-          , repo
-          , version);
+      sprintf(slug, GITHUB_CONTENT_URL "%s/%s", repo, version);
     }
   }
   return slug;
@@ -889,8 +863,7 @@ clib_package_url_from_repo(const char *repo, const char *version) {
  * Parse the package author from the given `slug`
  */
 
-char *
-clib_package_parse_author(const char *slug) {
+char *clib_package_parse_author(const char *slug) {
   return parse_repo_owner(slug, DEFAULT_REPO_OWNER);
 }
 
@@ -898,8 +871,7 @@ clib_package_parse_author(const char *slug) {
  * Parse the package version from the given `slug`
  */
 
-char *
-clib_package_parse_version(const char *slug) {
+char *clib_package_parse_version(const char *slug) {
   return parse_repo_version(slug, DEFAULT_REPO_VERSION);
 }
 
@@ -907,8 +879,7 @@ clib_package_parse_version(const char *slug) {
  * Parse the package name from the given `slug`
  */
 
-char *
-clib_package_parse_name(const char *slug) {
+char *clib_package_parse_name(const char *slug) {
   return parse_repo_name(slug);
 }
 
@@ -916,18 +887,18 @@ clib_package_parse_name(const char *slug) {
  * Create a new package dependency from the given `repo` and `version`
  */
 
-clib_package_dependency_t *
-clib_package_dependency_new(const char *repo, const char *version) {
-  if (!repo || !version) return NULL;
+clib_package_dependency_t *clib_package_dependency_new(const char *repo,
+                                                       const char *version) {
+  if (!repo || !version)
+    return NULL;
 
   clib_package_dependency_t *dep = malloc(sizeof(clib_package_dependency_t));
   if (!dep) {
     return NULL;
   }
 
-  dep->version = 0 == strcmp("*", version)
-    ? strdup(DEFAULT_REPO_VERSION)
-    : strdup(version);
+  dep->version = 0 == strcmp("*", version) ? strdup(DEFAULT_REPO_VERSION)
+                                           : strdup(version);
   dep->name = clib_package_parse_name(repo);
   dep->author = clib_package_parse_author(repo);
 
@@ -935,13 +906,8 @@ clib_package_dependency_new(const char *repo, const char *version) {
   return dep;
 }
 
-static int
-fetch_package_file_work(
-    clib_package_t *pkg
-  , const char *dir
-  , char *file
-  , int verbose
-) {
+static int fetch_package_file_work(clib_package_t *pkg, const char *dir,
+                                   char *file, int verbose) {
   char *url = NULL;
   char *path = NULL;
   int saved = 0;
@@ -971,7 +937,7 @@ fetch_package_file_work(
   }
 
 #ifdef HAVE_PTHREADS
-      pthread_mutex_lock(&lock.mutex);
+  pthread_mutex_lock(&lock.mutex);
 #endif
 
   if (1 == opts.force || -1 == fs_exists(path)) {
@@ -981,17 +947,16 @@ fetch_package_file_work(
     }
 
 #ifdef HAVE_PTHREADS
-      pthread_mutex_unlock(&lock.mutex);
+    pthread_mutex_unlock(&lock.mutex);
 #endif
 
     rc = http_get_file_shared(url, path, clib_package_curl_share);
     saved = 1;
   } else {
 #ifdef HAVE_PTHREADS
-      pthread_mutex_unlock(&lock.mutex);
+    pthread_mutex_unlock(&lock.mutex);
 #endif
   }
-
 
   if (-1 == rc) {
     if (verbose) {
@@ -1029,19 +994,15 @@ cleanup:
 }
 
 #ifdef HAVE_PTHREADS
-static void *
-fetch_package_file_thread(void *arg) {
+static void *fetch_package_file_thread(void *arg) {
   fetch_package_file_thread_data_t *data = arg;
   int *status = malloc(sizeof(int));
-  int rc = fetch_package_file_work(
-      data->pkg
-    , data->dir
-    , data->file
-    , data->verbose);
+  int rc =
+      fetch_package_file_work(data->pkg, data->dir, data->file, data->verbose);
   *status = rc;
-  (void) data->pkg->refs--;
-  pthread_exit((void *) status);
-  return (void *) rc;
+  (void)data->pkg->refs--;
+  pthread_exit((void *)status);
+  return (void *)rc;
 }
 #endif
 
@@ -1051,14 +1012,8 @@ fetch_package_file_thread(void *arg) {
  * Returns 0 on success.
  */
 
-static int
-fetch_package_file(
-    clib_package_t *pkg
-  , const char *dir
-  , char *file
-  , int verbose
-  , void **data
-) {
+static int fetch_package_file(clib_package_t *pkg, const char *dir, char *file,
+                              int verbose, void **data) {
 #ifndef HAVE_PTHREADS
   return fetch_package_file_work(pkg, dir, file, verbose);
 #else
@@ -1085,12 +1040,8 @@ fetch_package_file(
     return rc;
   }
 
-  (void) pkg->refs++;
-  rc = pthread_create(
-      &fetch->thread
-    , NULL
-    , fetch_package_file_thread
-    , fetch);
+  (void)pkg->refs++;
+  rc = pthread_create(&fetch->thread, NULL, fetch_package_file_thread, fetch);
 
   if (0 != rc) {
     pthread_attr_destroy(&fetch->attr);
@@ -1112,8 +1063,8 @@ fetch_package_file(
 #endif
 }
 
-int
-clib_package_install_executable(clib_package_t *pkg , char *dir, int verbose) {
+int clib_package_install_executable(clib_package_t *pkg, char *dir,
+                                    int verbose) {
 #ifdef PATH_MAX
   long path_max = PATH_MAX;
 #elif defined(_PC_PATH_MAX)
@@ -1152,39 +1103,29 @@ clib_package_install_executable(clib_package_t *pkg , char *dir, int verbose) {
   }
 
   reponame = strrchr(pkg->repo, '/');
-  if (reponame && *reponame != '\0') reponame++;
+  if (reponame && *reponame != '\0')
+    reponame++;
   else {
     if (verbose) {
-      logger_error(
-        "error",
-        "malformed repo field, must be in the form user/pkg");
+      logger_error("error",
+                   "malformed repo field, must be in the form user/pkg");
     }
     return -1;
   }
 
-  E_FORMAT(&url
-    , "https://github.com/%s/archive/%s.tar.gz"
-    , pkg->repo
-    , pkg->version);
+  E_FORMAT(&url, "https://github.com/%s/archive/%s.tar.gz", pkg->repo,
+           pkg->version);
 
-  E_FORMAT(&file
-    , "%s-%s.tar.gz"
-    , reponame
-    , pkg->version);
+  E_FORMAT(&file, "%s-%s.tar.gz", reponame, pkg->version);
 
-  E_FORMAT(&tarball
-    , "%s/%s"
-    , tmp, file);
+  E_FORMAT(&tarball, "%s/%s", tmp, file);
 
   rc = http_get_file_shared(url, tarball, clib_package_curl_share);
 
   if (0 != rc) {
     if (verbose) {
-      logger_error("error"
-        , "download failed for '%s@%s' - HTTP GET '%s'"
-        , pkg->repo
-        , pkg->version
-        , url);
+      logger_error("error", "download failed for '%s@%s' - HTTP GET '%s'",
+                   pkg->repo, pkg->version, url);
     }
 
     goto cleanup;
@@ -1199,7 +1140,8 @@ clib_package_install_executable(clib_package_t *pkg , char *dir, int verbose) {
 
   // cheap untar
   rc = system(command);
-  if (0 != rc) goto cleanup;
+  if (0 != rc)
+    goto cleanup;
 
   free(command);
   command = NULL;
@@ -1230,7 +1172,7 @@ clib_package_install_executable(clib_package_t *pkg , char *dir, int verbose) {
 
   char *version = pkg->version;
   if ('v' == version[0]) {
-    (void) version++;
+    (void)version++;
   }
 
   E_FORMAT(&unpack_dir, "%s/%s-%s", tmp, reponame, version);
@@ -1241,16 +1183,13 @@ clib_package_install_executable(clib_package_t *pkg , char *dir, int verbose) {
     E_FORMAT(&deps, "%s/deps", unpack_dir);
     _debug("deps: %s", deps);
     rc = clib_package_install_dependencies(pkg, deps, verbose);
-    if (-1 == rc) goto cleanup;
+    if (-1 == rc)
+      goto cleanup;
   }
 
   if (!opts.global && pkg->makefile) {
-    E_FORMAT(&command
-        , "cp -fr %s/%s/%s %s"
-        , dir_path
-        , pkg->name
-        , basename(pkg->makefile)
-        , unpack_dir);
+    E_FORMAT(&command, "cp -fr %s/%s/%s %s", dir_path, pkg->name,
+             basename(pkg->makefile), unpack_dir);
 
     rc = system(command);
     if (0 != rc) {
@@ -1277,9 +1216,7 @@ clib_package_install_executable(clib_package_t *pkg , char *dir, int verbose) {
     setenv("CFLAGS", cflags, 1);
   }
 
-  E_FORMAT(&command, "cd %s && %s"
-      , unpack_dir
-      , pkg->install);
+  E_FORMAT(&command, "cd %s && %s", unpack_dir, pkg->install);
 
   _debug("command(install): %s", command);
   rc = system(command);
@@ -1297,8 +1234,7 @@ cleanup:
  * Install the given `pkg` in `dir`
  */
 
-int
-clib_package_install(clib_package_t *pkg, const char *dir, int verbose) {
+int clib_package_install(clib_package_t *pkg, const char *dir, int verbose) {
   list_iterator_t *iterator = NULL;
   char *package_json = NULL;
   char *pkg_dir = NULL;
@@ -1381,16 +1317,16 @@ clib_package_install(clib_package_t *pkg, const char *dir, int verbose) {
   }
 
 #ifdef HAVE_PTHREADS
-    fetch_package_file_thread_data_t **fetchs = 0;
-    if (NULL != pkg && NULL != pkg->src) {
-      if (pkg->src->len > 0) {
-        fetchs = malloc(pkg->src->len * sizeof(fetch_package_file_thread_data_t));
-      }
+  fetch_package_file_thread_data_t **fetchs = 0;
+  if (NULL != pkg && NULL != pkg->src) {
+    if (pkg->src->len > 0) {
+      fetchs = malloc(pkg->src->len * sizeof(fetch_package_file_thread_data_t));
     }
+  }
 
-    if (fetchs) {
-      memset(fetchs, 0, pkg->src->len * sizeof(fetch_package_file_thread_data_t));
-    }
+  if (fetchs) {
+    memset(fetchs, 0, pkg->src->len * sizeof(fetch_package_file_thread_data_t));
+  }
 
 #endif
 
@@ -1414,9 +1350,7 @@ clib_package_install(clib_package_t *pkg, const char *dir, int verbose) {
   }
 
   if (NULL == pkg->url) {
-    pkg->url = clib_package_url(pkg->author
-      , pkg->repo_name
-      , pkg->version);
+    pkg->url = clib_package_url(pkg->author, pkg->repo_name, pkg->version);
 
     if (NULL == pkg->url) {
       rc = -1;
@@ -1465,14 +1399,15 @@ clib_package_install(clib_package_t *pkg, const char *dir, int verbose) {
     if (0 != fetch) {
       fetch_package_file_thread_data_t *data = fetch;
       int *status = 0;
-      pthread_join(data->thread, (void **) &status);
+      pthread_join(data->thread, (void **)&status);
       if (0 != status) {
         rc = *status;
         free(status);
         status = 0;
         if (0 != rc) {
           rc = 0;
-          logger_warn("warning", "unable to fetch Makefile (%s) for '%s'", pkg->makefile, pkg->name);
+          logger_warn("warning", "unable to fetch Makefile (%s) for '%s'",
+                      pkg->makefile, pkg->name);
         }
       }
     }
@@ -1480,24 +1415,26 @@ clib_package_install(clib_package_t *pkg, const char *dir, int verbose) {
   }
 
   // if no sources are listed, just install
-  if (opts.global || NULL == pkg->src) goto install;
+  if (opts.global || NULL == pkg->src)
+    goto install;
 
 #ifdef HAVE_PTHREADS
-    pthread_mutex_lock(&lock.mutex);
+  pthread_mutex_lock(&lock.mutex);
 #endif
 
   if (clib_cache_has_package(pkg->author, pkg->name, pkg->version)) {
     if (opts.skip_cache) {
-        clib_cache_delete_package(pkg->author, pkg->name, pkg->version);
+      clib_cache_delete_package(pkg->author, pkg->name, pkg->version);
 #ifdef HAVE_PTHREADS
-    pthread_mutex_unlock(&lock.mutex);
+      pthread_mutex_unlock(&lock.mutex);
 #endif
-        goto download;
+      goto download;
     }
 
-    if (0 != clib_cache_load_package(pkg->author, pkg->name, pkg->version, pkg_dir)){
+    if (0 != clib_cache_load_package(pkg->author, pkg->name, pkg->version,
+                                     pkg_dir)) {
 #ifdef HAVE_PTHREADS
-    pthread_mutex_unlock(&lock.mutex);
+      pthread_mutex_unlock(&lock.mutex);
 #endif
       goto download;
     }
@@ -1514,7 +1451,7 @@ clib_package_install(clib_package_t *pkg, const char *dir, int verbose) {
   }
 
 #ifdef HAVE_PTHREADS
-    pthread_mutex_unlock(&lock.mutex);
+  pthread_mutex_unlock(&lock.mutex);
 #endif
 
 download:
@@ -1533,7 +1470,7 @@ download:
       goto cleanup;
     }
 
-#if defined (__unix__) || (defined (__APPLE__) && defined (__MACH__))
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
     usleep(1024 * 10);
 #endif
 
@@ -1544,19 +1481,19 @@ download:
 
     fetchs[i] = fetch;
 
-    (void) pending++;
+    (void)pending++;
 
     if (i < max) {
-      (void) i++;
+      (void)i++;
     } else {
       while (--i >= 0) {
         fetch_package_file_thread_data_t *data = fetchs[i];
         int *status = 0;
-        pthread_join(data->thread, (void **) status);
+        pthread_join(data->thread, (void **)status);
         free(data);
         fetchs[i] = NULL;
 
-        (void) pending--;
+        (void)pending--;
 
         if (0 != status) {
           rc = *status;
@@ -1569,7 +1506,7 @@ download:
           goto cleanup;
         }
 
-#if defined (__unix__) || (defined (__APPLE__) && defined (__MACH__))
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
         usleep(1024 * 10);
 #endif
       }
@@ -1582,9 +1519,9 @@ download:
     fetch_package_file_thread_data_t *data = fetchs[i];
     int *status = 0;
 
-    pthread_join(data->thread, (void **) status);
+    pthread_join(data->thread, (void **)status);
 
-    (void) pending--;
+    (void)pending--;
     free(data);
     fetchs[i] = NULL;
 
@@ -1602,11 +1539,11 @@ download:
 #endif
 
 #ifdef HAVE_PTHREADS
-    pthread_mutex_lock(&lock.mutex);
+  pthread_mutex_lock(&lock.mutex);
 #endif
   clib_cache_save_package(pkg->author, pkg->name, pkg->version, pkg_dir);
 #ifdef HAVE_PTHREADS
-    pthread_mutex_unlock(&lock.mutex);
+  pthread_mutex_unlock(&lock.mutex);
 #endif
 
 install:
@@ -1625,18 +1562,14 @@ install:
       setenv("PREFIX", path, 1);
     }
 
-    E_FORMAT(&command
-        , "cd %s/%s && %s"
-        , dir
-        , pkg->name
-        , pkg->configure);
+    E_FORMAT(&command, "cd %s/%s && %s", dir, pkg->name, pkg->configure);
 
-      _debug("command(configure): %s", command);
+    _debug("command(configure): %s", command);
 
-      rc = system(command);
-      if (0 != rc) goto cleanup;
+    rc = system(command);
+    if (0 != rc)
+      goto cleanup;
   }
-
 
   if (0 == rc && pkg->install) {
     rc = clib_package_install_executable(pkg, dir, verbose);
@@ -1647,10 +1580,14 @@ install:
   }
 
 cleanup:
-  if (pkg_dir) free(pkg_dir);
-  if (package_json) free(package_json);
-  if (iterator) list_iterator_destroy(iterator);
-  if (command) free(command);
+  if (pkg_dir)
+    free(pkg_dir);
+  if (package_json)
+    free(package_json);
+  if (iterator)
+    list_iterator_destroy(iterator);
+  if (command)
+    free(command);
 #ifdef HAVE_PTHREADS
   if (NULL != pkg && NULL != pkg->src) {
     if (pkg->src->len > 0) {
@@ -1668,12 +1605,12 @@ cleanup:
  * Install the given `pkg`'s dependencies in `dir`
  */
 
-int
-clib_package_install_dependencies(clib_package_t *pkg
-    , const char *dir
-    , int verbose) {
-  if (!pkg || !dir) return -1;
-  if (NULL == pkg->dependencies) return 0;
+int clib_package_install_dependencies(clib_package_t *pkg, const char *dir,
+                                      int verbose) {
+  if (!pkg || !dir)
+    return -1;
+  if (NULL == pkg->dependencies)
+    return 0;
 
   return install_packages(pkg->dependencies, dir, verbose);
 }
@@ -1682,12 +1619,12 @@ clib_package_install_dependencies(clib_package_t *pkg
  * Install the given `pkg`'s development dependencies in `dir`
  */
 
-int
-clib_package_install_development(clib_package_t *pkg
-    , const char *dir
-    , int verbose) {
-  if (!pkg || !dir) return -1;
-  if (NULL == pkg->development) return 0;
+int clib_package_install_development(clib_package_t *pkg, const char *dir,
+                                     int verbose) {
+  if (!pkg || !dir)
+    return -1;
+  if (NULL == pkg->development)
+    return 0;
 
   return install_packages(pkg->development, dir, verbose);
 }
@@ -1696,8 +1633,7 @@ clib_package_install_development(clib_package_t *pkg
  * Free a clib package
  */
 
-void
-clib_package_free(clib_package_t *pkg) {
+void clib_package_free(clib_package_t *pkg) {
   if (NULL == pkg) {
     return;
   }
@@ -1706,7 +1642,11 @@ clib_package_free(clib_package_t *pkg) {
     return;
   }
 
-#define FREE(k) if (pkg->k) { free(pkg->k); pkg->k = 0; }
+#define FREE(k)                                                                \
+  if (pkg->k) {                                                                \
+    free(pkg->k);                                                              \
+    pkg->k = 0;                                                                \
+  }
   FREE(author);
   FREE(description);
   FREE(install);
@@ -1722,34 +1662,35 @@ clib_package_free(clib_package_t *pkg) {
   FREE(flags);
 #undef FREE
 
-  if (pkg->src) list_destroy(pkg->src);
+  if (pkg->src)
+    list_destroy(pkg->src);
   pkg->src = 0;
 
-  if (pkg->dependencies) list_destroy(pkg->dependencies);
+  if (pkg->dependencies)
+    list_destroy(pkg->dependencies);
   pkg->dependencies = 0;
 
-  if (pkg->development) list_destroy(pkg->development);
+  if (pkg->development)
+    list_destroy(pkg->development);
   pkg->development = 0;
 
   free(pkg);
   pkg = 0;
 }
 
-void
-clib_package_dependency_free(void *_dep) {
-  clib_package_dependency_t *dep = (clib_package_dependency_t *) _dep;
+void clib_package_dependency_free(void *_dep) {
+  clib_package_dependency_t *dep = (clib_package_dependency_t *)_dep;
   free(dep->name);
   free(dep->author);
   free(dep->version);
   free(dep);
 }
 
-void
-clib_package_cleanup() {
+void clib_package_cleanup() {
   if (0 != visited_packages) {
     hash_each(visited_packages, {
-      free((void *) key);
-      (void) val;
+      free((void *)key);
+      (void)val;
     });
 
     hash_free(visited_packages);

--- a/src/common/clib-package.h
+++ b/src/common/clib-package.h
@@ -9,8 +9,8 @@
 #ifndef CLIB_PACKAGE_H
 #define CLIB_PACKAGE_H 1
 
-#include <curl/curl.h>
 #include "list/list.h"
+#include <curl/curl.h>
 
 typedef struct {
   char *name;
@@ -52,58 +52,42 @@ typedef struct {
 
 extern CURLSH *clib_package_curl_share;
 
-void
-clib_package_set_opts(clib_package_opts_t opts);
+void clib_package_set_opts(clib_package_opts_t opts);
 
-clib_package_t *
-clib_package_new(const char *, int);
+clib_package_t *clib_package_new(const char *, int);
 
-clib_package_t *
-clib_package_new_from_slug(const char *, int);
+clib_package_t *clib_package_new_from_slug(const char *, int);
 
-clib_package_t *
-clib_package_load_from_manifest(const char*, int);
+clib_package_t *clib_package_load_from_manifest(const char *, int);
 
-clib_package_t *
-clib_package_load_local_manifest(int);
+clib_package_t *clib_package_load_local_manifest(int);
 
-char *
-clib_package_url(const char *, const char *, const char *);
+char *clib_package_url(const char *, const char *, const char *);
 
-char *
-clib_package_url_from_repo(const char *repo, const char *version);
+char *clib_package_url_from_repo(const char *repo, const char *version);
 
-char *
-clib_package_parse_version(const char *);
+char *clib_package_parse_version(const char *);
 
-char *
-clib_package_parse_author(const char *);
+char *clib_package_parse_author(const char *);
 
-char *
-clib_package_parse_name(const char *);
+char *clib_package_parse_name(const char *);
 
-clib_package_dependency_t *
-clib_package_dependency_new(const char *, const char *);
+clib_package_dependency_t *clib_package_dependency_new(const char *,
+                                                       const char *);
 
-int
-clib_package_install_executable(clib_package_t *pkg, char *dir, int verbose);
+int clib_package_install_executable(clib_package_t *pkg, char *dir,
+                                    int verbose);
 
-int
-clib_package_install(clib_package_t *, const char *, int);
+int clib_package_install(clib_package_t *, const char *, int);
 
-int
-clib_package_install_dependencies(clib_package_t *, const char *, int);
+int clib_package_install_dependencies(clib_package_t *, const char *, int);
 
-int
-clib_package_install_development(clib_package_t *, const char *, int);
+int clib_package_install_development(clib_package_t *, const char *, int);
 
-void
-clib_package_free(clib_package_t *);
+void clib_package_free(clib_package_t *);
 
-void
-clib_package_dependency_free(void *);
+void clib_package_dependency_free(void *);
 
-void
-clib_package_cleanup();
+void clib_package_cleanup();
 
 #endif


### PR DESCRIPTION
This patch introduces `clang-format` to ensure our source files have consistent "code style".

Two new Make targets have been created:

- `make fmt`: run `clang-format` on all source files (in the `src/` directory)
- `make commit-hook`: install a `pre-commit` hook for automatically running `clang-format` on changes

Closes #208