### PR TITLE
Logging future change in clib upgrade

### DIFF
--- a/src/clib-upgrade.c
+++ b/src/clib-upgrade.c
@@ -138,11 +138,16 @@ static int install_package(const char *slug) {
   if (0 != extended_slug) {
     pkg = clib_package_new_from_slug(extended_slug, opts.verbose);
   } else {
+    logger_warn("warn", "In clib 2.6.0, this functionality will change. We will default to the latest tag rather than the master branch.")
     pkg = clib_package_new_from_slug(slug, opts.verbose);
   }
 
-  if (NULL == pkg)
+  if (NULL == pkg) {
+    if (opts.tag) {
+      logger_error("error", "Unable to install tag %s. Please make sure it actually exists.", opts.tag);
+    }
     return -1;
+  }
 
   if (root_package && root_package->prefix) {
     package_opts.prefix = root_package->prefix;
@@ -209,7 +214,7 @@ int main(int argc, char *argv[]) {
                  setopt_slug);
   command_option(&program, "-T", "--tag <tag>",
                  "The tag to upgrade to (usually it is the latest)",
-                 setopt_token);
+                 setopt_tag);
 #ifdef HAVE_PTHREADS
   command_option(&program, "-C", "--concurrency <number>",
                  "Set concurrency (default: " S(MAX_THREADS) ")",

--- a/src/clib-upgrade.c
+++ b/src/clib-upgrade.c
@@ -138,13 +138,18 @@ static int install_package(const char *slug) {
   if (0 != extended_slug) {
     pkg = clib_package_new_from_slug(extended_slug, opts.verbose);
   } else {
-    logger_warn("warn", "In clib 2.6.0, this functionality will change. We will default to the latest tag rather than the master branch.")
-    pkg = clib_package_new_from_slug(slug, opts.verbose);
+    logger_warn("warn",
+                "In clib 2.6.0, this functionality will change. We will "
+                "default to the latest tag rather than the master branch.")
+        pkg = clib_package_new_from_slug(slug, opts.verbose);
   }
 
   if (NULL == pkg) {
     if (opts.tag) {
-      logger_error("error", "Unable to install tag %s. Please make sure it actually exists.", opts.tag);
+      logger_error(
+          "error",
+          "Unable to install tag %s. Please make sure it actually exists.",
+          opts.tag);
     }
     return -1;
   }


### PR DESCRIPTION
- This PR adds a warning for a future change in `clib upgrade` (#212). In the log I marked 2.6.0 for the change, so 3 releases from now, I think it's a reasonable time for that, but please let me know what you think about that.
- Fixes a bug where the `--tag` option was ignored.
- Adds an error log when a tag cannot be installed.

I hope it's okay that I coupled a few small things to this PR. :smile: 