### PR TITLE
Add fuzzer

### DIFF
--- a/test/fuzzing/fuzz_manifest.c
+++ b/test/fuzzing/fuzz_manifest.c
@@ -1,0 +1,24 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include "../../src/common/clib-package.h"
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    if(size<3){
+            return 0;
+    }
+    char filename[256];
+    sprintf(filename, "libfuzzer.json");
+
+    FILE *fp = fopen(filename, "wb");
+    if (!fp)
+            return 0;
+    fwrite(data, size, 1, fp);
+    fclose(fp);
+    
+    clib_package_load_from_manifest(filename, 0);
+    
+    unlink(filename);
+    return 0;
+}


### PR DESCRIPTION
This PR adds a fuzzer that targets clib_package_load_from_manifest.

The fuzzer can be run locally and I can confirm that it runs on oss-fuzz's infrastructure as well. I will be happy to setup an integration application into oss-fuzz if the maintainers of Clib are interested in running this fuzzer continuously and in fixing bugs if any should be found.

Integration into oss-fuzz is free, but bugs need to be fixed so that the resources spent on fuzzing Clib are put to good use. Oss-fuzz has a 90 day disclosure policy.