### PR TITLE
Removing deprecated -v flag

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -139,6 +139,7 @@ $ clib install visionmedia/mon visionmedia/every visionmedia/watch
  If you have any issues, questions or suggestions, please open an issue [here](https://github.com/clibs/clib/issues). 
  
  You can also find us on Gitter: https://gitter.im/clibs/clib
+ Also feel free to open a GitHub Discussion [here](https://github.com/clibs/clib/discussions).
 
  Before committing to the repository, please run `make commit-hook`. This installs a commit hook which formats `.c` and `.h` files.
 

--- a/src/clib.c
+++ b/src/clib.c
@@ -158,11 +158,6 @@ int main(int argc, const char **argv) {
     return 0;
   }
 
-  if (0 == strncmp(argv[1], "-v", 2)) {
-    fprintf(stderr, "Deprecated flag: \"-v\". Please use \"-V\"\n");
-    argv[1] = "-V";
-  }
-
   // version
   if (0 == strncmp(argv[1], "-V", 2) || 0 == strncmp(argv[1], "--version", 9)) {
     printf("%s\n", CLIB_VERSION);


### PR DESCRIPTION
This small change removes the long time deprecated `-v` flag in favor of  `-V`, also adds small notice about GitHub Discussion in the Readme.md.