### PR TITLE
Fix memory leak

### DIFF
--- a/src/clib-configure.c
+++ b/src/clib-configure.c
@@ -1,7 +1,7 @@
 //
 // clib-configure.c
 //
-// Copyright (c) 2012-2020 clib authors
+// Copyright (c) 2012-2021 clib authors
 // MIT licensed
 //
 
@@ -122,7 +122,7 @@ void *configure_package_with_manifest_name_thread(void *arg) {
 
 int configure_package_with_manifest_name(const char *dir, const char *file) {
   clib_package_t *package = 0;
-  char *json = 0;
+  char *json = NULL;
   int ok = 0;
   int rc = 0;
 
@@ -146,7 +146,6 @@ int configure_package_with_manifest_name(const char *dir, const char *file) {
 
   if (!root_package) {
     const char *name = NULL;
-    char *json = NULL;
     unsigned int i = 0;
 
     do {
@@ -180,6 +179,9 @@ int configure_package_with_manifest_name(const char *dir, const char *file) {
 #ifdef HAVE_PTHREADS
   pthread_mutex_unlock(&mutex);
 #endif
+
+  // Free the json if it was allocated before attempting to modify it
+  free(json);
 
   if (0 == fs_exists(path)) {
     debug(&debugger, "read %s", path);


### PR DESCRIPTION
Frees the json pointer if it was allocated before attempting to modify it.

Before:

```
$ valgrind --tool=memcheck --leak-check=yes clib-configure
[...]
 LEAK SUMMARY:
    definitely lost: 1,268 bytes in 2 blocks
    indirectly lost: 0 bytes in 0 blocks
      possibly lost: 0 bytes in 0 blocks
    still reachable: 3,108 bytes in 163 blocks
        suppressed: 0 bytes in 0 blocks
```

Just from running this command, we lost over 1.2k of memory. Thats about 0.00023% of the raspberry pi zero's ram (512Mbs). Lol :)

After:

```
$ valgrind --tool=memcheck --leak-check=yes ~/github-repo/westleyr-clib/clib/clib-configure
[...]
    definitely lost: 9 bytes in 1 blocks
    indirectly lost: 0 bytes in 0 blocks
      possibly lost: 0 bytes in 0 blocks
    still reachable: 3,108 bytes in 163 blocks
         suppressed: 0 bytes in 0 blocks
```

As you can see, its a lot better, not perfect, but better.

_Disclaimer: I'm not exactly sure what `clib configure` does, I did not find documentation for what exactly that command does. But I'm pretty sure my modification did not break anything._