### PR TITLE
Fixed memory leak for clib-search

### DIFF
--- a/src/clib-search.c
+++ b/src/clib-search.c
@@ -1,7 +1,7 @@
 //
 // clib-search.c
 //
-// Copyright (c) 2012-2020 clib authors
+// Copyright (c) 2012-2021 clib authors
 // MIT licensed
 //
 
@@ -85,8 +85,10 @@ static int matches(int count, char *args[], wiki_package_t *pkg) {
   COMPARE(href);
 
 cleanup:
-  free(name);
   free(description);
+  free(name);
+  free(repo);
+  free(href);
   return rc;
 }
 


### PR DESCRIPTION
Frees all pointers from strdup.

Before:

```
$ clib-search foo
[...]
Process 71040: 1070 nodes malloced for 55 KB
Process 71040: 562 leaks for 19648 total leaked bytes.

    562 (19.2K) << TOTAL >>
```

Yup, almost a whopping 20Kbs of leaked memory.

After:

```
$ clib-search foo
[...]
Process 71043: 508 nodes malloced for 36 KB
Process 71043: 0 leaks for 0 total leaked bytes.
```

And now, there is no leaks!