### PR TITLE
Expire the search cache

### DIFF
--- a/src/common/clib-cache.c
+++ b/src/common/clib-cache.c
@@ -132,7 +132,9 @@ int clib_cache_delete_json(char *author, char *name, char *version) {
   return unlink(json_cache);
 }
 
-int clib_cache_has_search(void) { return 0 == fs_exists(search_cache); }
+int clib_cache_has_search(void) {
+  return 0 == fs_exists(search_cache) && !is_expired(search_cache);
+}
 
 char *clib_cache_read_search(void) {
   if (!clib_cache_has_search()) {

--- a/test/cache/cache-test.c
+++ b/test/cache/cache-test.c
@@ -5,6 +5,7 @@
 #include <limits.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 
 #define assert_exists(f) assert_equal(0, fs_exists(f));
 
@@ -36,11 +37,15 @@ int main() {
     char *version = "1.2.0";
     char pkg_dir[BUFSIZ];
 
-    it("should initialize succesfully") { assert_equal(0, clib_cache_init(1)); }
+    int expiraton = 1;
+
+    it("should initialize succesfully") {
+      assert_equal(0, clib_cache_init(expiraton));
+    }
 
     sprintf(pkg_dir, "%s/author_pkg_1.2.0", clib_cache_dir());
 
-    it("should manage package the cache") {
+    it("should manage the package cache") {
       assert_equal(
           0, clib_cache_save_package(author, name, version, "../../deps/copy"));
       assert_equal(1, clib_cache_has_package(author, name, version));
@@ -84,6 +89,17 @@ int main() {
       assert_equal(0, clib_cache_delete_search());
       assert_equal(0, clib_cache_has_search());
       assert_null(clib_cache_read_search());
+    }
+
+    it("should expire the search cache") {
+      clib_cache_delete_search();
+
+      assert_equal(13, clib_cache_save_search("<html></html>"));
+      assert_equal(1, clib_cache_has_search());
+
+      sleep(expiraton + 1);
+
+      assert_equal(0, clib_cache_has_search());
     }
   }
 

--- a/test/cache/cache-test.c
+++ b/test/cache/cache-test.c
@@ -101,6 +101,8 @@ int main() {
 
       assert_equal(0, clib_cache_has_search());
     }
+
+    clib_cache_delete_search();
   }
 
   return assert_failures();


### PR DESCRIPTION
The search HTML cache was never expired. Fixed it to use the expiration time set by `clib_cache_init`.