### PR TITLE
Fixing compiler warnings

### DIFF
--- a/src/clib-upgrade.c
+++ b/src/clib-upgrade.c
@@ -138,7 +138,7 @@ static int install_package(const char *slug) {
     const char *latest_tag = clib_release_get_latest_tag();
 
     asprintf(&extended_slug, "%s@%s", slug, latest_tag);
-    free(latest_tag);
+    free((void *)latest_tag);
   }
 
   logger_info("info", "Upgrading to %s", extended_slug);

--- a/src/clib.c
+++ b/src/clib.c
@@ -89,7 +89,7 @@ static void compare_versions(const char *marker_file_path) {
                 "upgrade with the following command: clib upgrade --tag %s",
                 CLIB_VERSION, latest_version);
   }
-  free((void*)latest_version);
+  free((void *)latest_version);
 }
 
 static void notify_new_release(void) {

--- a/src/clib.c
+++ b/src/clib.c
@@ -89,7 +89,7 @@ static void compare_versions(const char *marker_file_path) {
                 "upgrade with the following command: clib upgrade --tag %s",
                 CLIB_VERSION, latest_version);
   }
-  free(latest_version);
+  free((void*)latest_version);
 }
 
 static void notify_new_release(void) {

--- a/src/common/clib-package.c
+++ b/src/common/clib-package.c
@@ -1003,7 +1003,7 @@ static void *fetch_package_file_thread(void *arg) {
   *status = rc;
   (void)data->pkg->refs--;
   pthread_exit((void *)status);
-  return (void *)rc;
+  return (void *)(intptr_t)rc;
 }
 #endif
 
@@ -1081,7 +1081,7 @@ static void set_prefix(clib_package_t *pkg, long path_max) {
   }
 }
 
-int clib_package_install_executable(clib_package_t *pkg, char *dir,
+int clib_package_install_executable(clib_package_t *pkg, const char *dir,
                                     int verbose) {
 #ifdef PATH_MAX
   long path_max = PATH_MAX;

--- a/src/common/clib-package.h
+++ b/src/common/clib-package.h
@@ -75,7 +75,7 @@ char *clib_package_parse_name(const char *);
 clib_package_dependency_t *clib_package_dependency_new(const char *,
                                                        const char *);
 
-int clib_package_install_executable(clib_package_t *pkg, char *dir,
+int clib_package_install_executable(clib_package_t *pkg, const char *dir,
                                     int verbose);
 
 int clib_package_install(clib_package_t *, const char *, int);


### PR DESCRIPTION
Fixing compiler warnings when executing `make`