### PR TITLE
clib init can't always determine the current directory name

### DIFF
--- a/src/clib-init.c
+++ b/src/clib-init.c
@@ -54,12 +54,10 @@ static void setopt_manifest_file(command_t *self) {
 static char *find_basepath() {
   char cwd[4096] = {0};
   getcwd(cwd, 4096);
-  char *walk = cwd + strlen(cwd);
-  while (*(--walk) != '/')
-    ;
-  char *basepath = malloc((size_t)(walk - cwd));
-  strncpy(basepath, walk + 1, (size_t)(walk - cwd));
-  return basepath;
+
+  char *s = strrchr(cwd, '/');
+
+  return strdup(s + 1);
 }
 
 static void getinput(char *buffer, size_t s) {

--- a/src/clib-init.c
+++ b/src/clib-init.c
@@ -55,9 +55,7 @@ static char *find_basepath() {
   char cwd[4096] = {0};
   getcwd(cwd, 4096);
 
-  char *s = strrchr(cwd, '/');
-
-  return strdup(s + 1);
+  return strdup(strrchr(cwd, '/') + 1);
 }
 
 static void getinput(char *buffer, size_t s) {


### PR DESCRIPTION
For example if I execute `clib init` in `/tmp` or `~` then I get the following:

```
package name (`˛�]U): 
```