### PR TITLE
Fix compile error on cygwin

### DIFF
--- a/src/clib-build.c
+++ b/src/clib-build.c
@@ -62,7 +62,7 @@
 #endif
 
 #if defined(_WIN32) || defined(WIN32) || defined(__MINGW32__) ||               \
-    defined(__MINGW64__) || defined(__CYGWIN__)
+    defined(__MINGW64__)
 #define setenv(k, v, _) _putenv_s(k, v)
 #define realpath(a, b) _fullpath(a, b, strlen(a))
 #endif

--- a/src/clib-configure.c
+++ b/src/clib-configure.c
@@ -54,7 +54,7 @@
 #endif
 
 #if defined(_WIN32) || defined(WIN32) || defined(__MINGW32__) ||               \
-    defined(__MINGW64__) || defined(__CYGWIN__)
+    defined(__MINGW64__)
 #define setenv(k, v, _) _putenv_s(k, v)
 #define realpath(a, b) _fullpath(a, b, strlen(a))
 #endif

--- a/src/clib-init.c
+++ b/src/clib-init.c
@@ -19,7 +19,7 @@
 #include <unistd.h>
 
 #if defined(_WIN32) || defined(WIN32) || defined(__MINGW32__) ||               \
-    defined(__MINGW64__) || defined(__CYGWIN__)
+    defined(__MINGW64__)
 #define setenv(k, v, _) _putenv_s(k, v)
 #define realpath(a, b) _fullpath(a, b, strlen(a))
 #endif

--- a/src/clib-install.c
+++ b/src/clib-install.c
@@ -33,7 +33,7 @@
 #endif
 
 #if defined(_WIN32) || defined(WIN32) || defined(__MINGW32__) ||               \
-    defined(__MINGW64__) || defined(__CYGWIN__)
+    defined(__MINGW64__)
 #define setenv(k, v, _) _putenv_s(k, v)
 #define realpath(a, b) _fullpath(a, b, strlen(a))
 #endif

--- a/src/clib-search.c
+++ b/src/clib-search.c
@@ -29,7 +29,7 @@
 #define CLIB_SEARCH_CACHE_TIME 1 * 24 * 60 * 60
 
 #if defined(_WIN32) || defined(WIN32) || defined(__MINGW32__) ||               \
-    defined(__MINGW64__) || defined(__CYGWIN__)
+    defined(__MINGW64__)
 #define setenv(k, v, _) _putenv_s(k, v)
 #define realpath(a, b) _fullpath(a, b, strlen(a))
 #endif

--- a/src/clib-uninstall.c
+++ b/src/clib-uninstall.c
@@ -22,7 +22,7 @@
 #define CLIB_UNINSTALL_DEFAULT_TARGET "make uninstall"
 
 #if defined(_WIN32) || defined(WIN32) || defined(__MINGW32__) ||               \
-    defined(__MINGW64__) || defined(__CYGWIN__)
+    defined(__MINGW64__)
 #define setenv(k, v, _) _putenv_s(k, v)
 #endif
 

--- a/src/clib-update.c
+++ b/src/clib-update.c
@@ -33,7 +33,7 @@
 #endif
 
 #if defined(_WIN32) || defined(WIN32) || defined(__MINGW32__) ||               \
-    defined(__MINGW64__) || defined(__CYGWIN__)
+    defined(__MINGW64__)
 #define setenv(k, v, _) _putenv_s(k, v)
 #define realpath(a, b) _fullpath(a, b, strlen(a))
 #endif

--- a/src/clib-upgrade.c
+++ b/src/clib-upgrade.c
@@ -35,7 +35,7 @@
 #endif
 
 #if defined(_WIN32) || defined(WIN32) || defined(__MINGW32__) ||               \
-    defined(__MINGW64__) || defined(__CYGWIN__)
+    defined(__MINGW64__)
 #define setenv(k, v, _) _putenv_s(k, v)
 #define realpath(a, b) _fullpath(a, b, strlen(a))
 #endif

--- a/src/common/clib-package.c
+++ b/src/common/clib-package.c
@@ -48,7 +48,7 @@
 #define GITHUB_CONTENT_URL_WITH_TOKEN "https://%s@raw.githubusercontent.com/"
 
 #if defined(_WIN32) || defined(WIN32) || defined(__MINGW32__) ||               \
-    defined(__MINGW64__) || defined(__CYGWIN__)
+    defined(__MINGW64__)
 #define setenv(k, v, _) _putenv_s(k, v)
 #define realpath(a, b) _fullpath(a, b, strlen(a))
 #endif


### PR DESCRIPTION
On cygwin, `setenv` and `realpath` are implemented
(`_putenv_s` and `_fullpath` are not implemented.)

```
src/common/clib-package.c: In function ‘set_prefix’:
src/common/clib-package.c:53:24: warning: implicit declaration of function ‘_fullpath’ [-Wimplicit-function-declaration]
   53 | #define realpath(a, b) _fullpath(a, b, strlen(a))
      |                        ^~~~~~~~~
src/common/clib-package.c:1077:7: note: in expansion of macro ‘realpath’
 1077 |       realpath(opts.prefix, path);
      |       ^~~~~~~~
src/common/clib-package.c:52:25: warning: implicit declaration of function ‘_putenv_s’; did you mean ‘_putenv_r’? [-Wimplicit-function-declaration]
   52 | #define setenv(k, v, _) _putenv_s(k, v)
      |                         ^~~~~~~~~
src/common/clib-package.c:1083:5: note: in expansion of macro ‘setenv’
 1083 |     setenv("PREFIX", path, 1);
      |     ^~~~~~
/usr/lib/gcc/x86_64-pc-cygwin/10/../../../../x86_64-pc-cygwin/bin/ld: /tmp/cc1FCosp.o:clib-package.c:(.text+0x28a9): undefined reference to `_fullpath'
/usr/lib/gcc/x86_64-pc-cygwin/10/../../../../x86_64-pc-cygwin/bin/ld: /tmp/cc1FCosp.o:clib-package.c:(.text+0x28d5): undefined reference to `_fullpath'
/usr/lib/gcc/x86_64-pc-cygwin/10/../../../../x86_64-pc-cygwin/bin/ld: /tmp/cc1FCosp.o:clib-package.c:(.text+0x2921): undefined reference to `_putenv_s'
/usr/lib/gcc/x86_64-pc-cygwin/10/../../../../x86_64-pc-cygwin/bin/ld: /tmp/cc1FCosp.o:clib-package.c:(.text+0x2f36): undefined reference to `_fullpath'
/usr/lib/gcc/x86_64-pc-cygwin/10/../../../../x86_64-pc-cygwin/bin/ld: /tmp/cc1FCosp.o:clib-package.c:(.text+0x316d): undefined reference to `_putenv_s'
collect2: error: ld returned 1 exit status
make: *** [Makefile:50: clib] Error 1
```
