### PR TITLE
Remove `kMessageBufferSize` variable which is unused

### DIFF
--- a/deps/gumbo-parser/error.c
+++ b/deps/gumbo-parser/error.c
@@ -27,8 +27,6 @@
 #include "util.h"
 #include "vector.h"
 
-static const size_t kMessageBufferSize = 256;
-
 // Prints a formatted message to a StringBuffer.  This automatically resizes the
 // StringBuffer as necessary to fit the message.  Returns the number of bytes
 // written.


### PR DESCRIPTION
This container was declared and assigned a value but never used; caught at compile time by GCC and flagged, hence removed.