### PR TITLE
Fix a memory issue when downloading files.

### DIFF
--- a/src/common/clib-package.c
+++ b/src/common/clib-package.c
@@ -1475,7 +1475,6 @@ download:
   while ((source = list_iterator_next(iterator))) {
     void *fetch = NULL;
     rc = fetch_package_file(pkg, pkg_dir, source->val, verbose, &fetch);
-    printf("Starting thread %d\n", i);
 
     if (0 != rc) {
       list_iterator_destroy(iterator);
@@ -1496,12 +1495,10 @@ download:
     if (i < (max - 1)) {
       (void)i++;
     } else {
-      printf("All threads in use, cleaning up.\n");
       for (int j = 0; j <= i; j++) {
         fetch_package_file_thread_data_t *data = fetchs[j];
         int *status;
         pthread_join(data->thread, (void **)&status);
-        printf("Joining thread %d\n", j);
         free(data);
         fetchs[j] = NULL;
 
@@ -1530,7 +1527,6 @@ download:
     int *status;
 
     pthread_join(data->thread, (void **)&status);
-    printf("Joining thread %d\n", j);
 
     (void)pending--;
     free(data);

--- a/src/common/clib-package.c
+++ b/src/common/clib-package.c
@@ -1475,6 +1475,7 @@ download:
   while ((source = list_iterator_next(iterator))) {
     void *fetch = NULL;
     rc = fetch_package_file(pkg, pkg_dir, source->val, verbose, &fetch);
+    printf("Starting thread %d\n", i);
 
     if (0 != rc) {
       list_iterator_destroy(iterator);
@@ -1499,10 +1500,12 @@ download:
     if (i < max) {
       (void)i++;
     } else {
+      printf("All threads in use, cleaning up.\n");
       while (--i >= 0) {
         fetch_package_file_thread_data_t *data = fetchs[i];
         int *status;
         pthread_join(data->thread, (void **)&status);
+        printf("Joining thread %d\n", i);
         free(data);
         fetchs[i] = NULL;
 
@@ -1533,6 +1536,7 @@ download:
     int *status;
 
     pthread_join(data->thread, (void **)&status);
+    printf("Joining thread %d\n", i);
 
     (void)pending--;
     free(data);


### PR DESCRIPTION
There is a bug in the multithreading code when downloading package files. I have added some debug statements to highlight the problem.

Without fix:
```
$ clib-install -c -f thlorenz/gumbo-parser.c
     warning : missing repo in clib.json or package.json file for (null)
       fetch : thlorenz/gumbo-parser.c:package.json
     warning : missing repo in clib.json or package.json file for gumbo-parser
Starting thread 0
       fetch : thlorenz/gumbo-parser:src/attribute.c
Starting thread 1
       fetch : thlorenz/gumbo-parser:src/attribute.h
Starting thread 2
       fetch : thlorenz/gumbo-parser:src/char_ref.c
Starting thread 3
       fetch : thlorenz/gumbo-parser:src/char_ref.h
Starting thread 4
       fetch : thlorenz/gumbo-parser:src/error.c
All threads in use, cleaning up.
        save : ./deps/gumbo-parser/attribute.c
        save : ./deps/gumbo-parser/char_ref.c
        save : ./deps/gumbo-parser/attribute.h
        save : ./deps/gumbo-parser/char_ref.h
Joining thread 3
Joining thread 2
        save : ./deps/gumbo-parser/error.c
Joining thread 1
Joining thread 0
Starting thread -1
       fetch : thlorenz/gumbo-parser:src/error.h
Starting thread 1
       fetch : thlorenz/gumbo-parser:src/gumbo.h
Starting thread 2
       fetch : thlorenz/gumbo-parser:src/insertion_mode.h
Starting thread 3
       fetch : thlorenz/gumbo-parser:src/parser.c
Starting thread 4
       fetch : thlorenz/gumbo-parser:src/parser.h
All threads in use, cleaning up.
        save : ./deps/gumbo-parser/error.h
        save : ./deps/gumbo-parser/parser.h
        save : ./deps/gumbo-parser/gumbo.h
        save : ./deps/gumbo-parser/insertion_mode.h
        save : ./deps/gumbo-parser/parser.c
Joining thread 3
Joining thread 2
Joining thread 1
Joining thread 0
Starting thread -1
       fetch : thlorenz/gumbo-parser:src/string_buffer.c
Starting thread 1
       fetch : thlorenz/gumbo-parser:src/string_buffer.h
Starting thread 2
       fetch : thlorenz/gumbo-parser:src/string_piece.c
Starting thread 3
       fetch : thlorenz/gumbo-parser:src/string_piece.h
Starting thread 4
       fetch : thlorenz/gumbo-parser:src/tag.c
All threads in use, cleaning up.
        save : ./deps/gumbo-parser/tag.c
        save : ./deps/gumbo-parser/string_buffer.c
        save : ./deps/gumbo-parser/string_buffer.h
        save : ./deps/gumbo-parser/string_piece.h
        save : ./deps/gumbo-parser/string_piece.c
Joining thread 3
Joining thread 2
Joining thread 1
Joining thread 0
Starting thread -1
       fetch : thlorenz/gumbo-parser:src/token_type.h
Starting thread 1
       fetch : thlorenz/gumbo-parser:src/tokenizer.c
Starting thread 2
       fetch : thlorenz/gumbo-parser:src/tokenizer.h
Starting thread 3
       fetch : thlorenz/gumbo-parser:src/tokenizer_states.h
Starting thread 4
       fetch : thlorenz/gumbo-parser:src/utf8.c
All threads in use, cleaning up.
        save : ./deps/gumbo-parser/token_type.h
        save : ./deps/gumbo-parser/utf8.c
        save : ./deps/gumbo-parser/tokenizer_states.h
        save : ./deps/gumbo-parser/tokenizer.h
Joining thread 3
Joining thread 2
        save : ./deps/gumbo-parser/tokenizer.c
Joining thread 1
Joining thread 0
Starting thread -1
       fetch : thlorenz/gumbo-parser:src/utf8.h
Starting thread 1
       fetch : thlorenz/gumbo-parser:src/util.c
Starting thread 2
       fetch : thlorenz/gumbo-parser:src/util.h
Starting thread 3
       fetch : thlorenz/gumbo-parser:src/vector.c
Starting thread 4
       fetch : thlorenz/gumbo-parser:src/vector.h
All threads in use, cleaning up.
        save : ./deps/gumbo-parser/util.h
        save : ./deps/gumbo-parser/util.c
        save : ./deps/gumbo-parser/vector.c
        save : ./deps/gumbo-parser/vector.h
        save : ./deps/gumbo-parser/utf8.h
Joining thread 3
Joining thread 2
Joining thread 1
Joining thread 0
Process finished with exit code 0
```


With fix:
```
$ clib-install -c -f thlorenz/gumbo-parser.c
     warning : missing repo in clib.json or package.json file for (null)
       fetch : thlorenz/gumbo-parser.c:package.json
     warning : missing repo in clib.json or package.json file for gumbo-parser
Starting thread 0
       fetch : thlorenz/gumbo-parser:src/attribute.c
Starting thread 1
Starting thread 2
       fetch : thlorenz/gumbo-parser:src/attribute.h
       fetch : thlorenz/gumbo-parser:src/char_ref.c
Starting thread 3
All threads in use, cleaning up.
       fetch : thlorenz/gumbo-parser:src/char_ref.h
        save : ./deps/gumbo-parser/attribute.c
Joining thread 0
        save : ./deps/gumbo-parser/char_ref.h
        save : ./deps/gumbo-parser/attribute.h
Joining thread 1
        save : ./deps/gumbo-parser/char_ref.c
Joining thread 2
Joining thread 3
Starting thread 0
Starting thread 1
Starting thread 2
       fetch : thlorenz/gumbo-parser:src/error.c
       fetchStarting thread 3
All threads in use, cleaning up.
 : thlorenz/gumbo-parser:src/gumbo.h
       fetch : thlorenz/gumbo-parser:src/insertion_mode.h
       fetch : thlorenz/gumbo-parser:src/error.h
        save : ./deps/gumbo-parser/error.h
        save : ./deps/gumbo-parser/error.c
Joining thread 0
Joining thread 1
        save : ./deps/gumbo-parser/gumbo.h
Joining thread 2
        save : ./deps/gumbo-parser/insertion_mode.h
Joining thread 3
Starting thread 0
       fetch : thlorenz/gumbo-parser:src/parser.c
Starting thread 1
       fetch : thlorenz/gumbo-parser:src/parser.h
Starting thread 2
       fetch : thlorenz/gumbo-parser:src/string_buffer.c
Starting thread 3
All threads in use, cleaning up.
       fetch : thlorenz/gumbo-parser:src/string_buffer.h
        save : ./deps/gumbo-parser/parser.h
        save : ./deps/gumbo-parser/string_buffer.c
        save : ./deps/gumbo-parser/string_buffer.h
        save : ./deps/gumbo-parser/parser.c
Joining thread 0
Joining thread 1
Joining thread 2
Joining thread 3
Starting thread 0
Starting thread 1
       fetch : thlorenz/gumbo-parser:src/string_piece.h
       fetch : thlorenz/gumbo-parser:src/tag.cStarting thread 2

Starting thread 3
All threads in use, cleaning up.
       fetch : thlorenz/gumbo-parser:src/token_type.h
       fetch : thlorenz/gumbo-parser:src/string_piece.c
        save : ./deps/gumbo-parser/string_piece.h
        save : ./deps/gumbo-parser/token_type.h
        save : ./deps/gumbo-parser/tag.c
        save : ./deps/gumbo-parser/string_piece.c
Joining thread 0
Joining thread 1
Joining thread 2
Joining thread 3
Starting thread 0
Starting thread 1
Starting thread 2
Starting thread 3
All threads in use, cleaning up.
       fetch : thlorenz/gumbo-parser:src/tokenizer.c
       fetch : thlorenz/gumbo-parser:src/tokenizer_states.h
       fetch : thlorenz/gumbo-parser:src/utf8.c
       fetch : thlorenz/gumbo-parser:src/tokenizer.h
        save : ./deps/gumbo-parser/tokenizer.h
        save : ./deps/gumbo-parser/tokenizer_states.h
        save : ./deps/gumbo-parser/utf8.c
        save : ./deps/gumbo-parser/tokenizer.c
Joining thread 0
Joining thread 1
Joining thread 2
Joining thread 3
Starting thread 0
Starting thread 1
Starting thread 2
       fetch : thlorenz/gumbo-parser:src/utf8.hStarting thread 3
All threads in use, cleaning up.

       fetch : thlorenz/gumbo-parser:src/util.c
       fetch : thlorenz/gumbo-parser:src/vector.c
       fetch : thlorenz/gumbo-parser:src/util.h
        save : ./deps/gumbo-parser/util.h
        save : ./deps/gumbo-parser/util.c
        save : ./deps/gumbo-parser/vector.c
        save : ./deps/gumbo-parser/utf8.h
Joining thread 0
Joining thread 1
Joining thread 2
Joining thread 3
Starting thread 0
       fetch : thlorenz/gumbo-parser:src/vector.h
        save : ./deps/gumbo-parser/vector.h
Joining thread 0
Process finished with exit code 0
```