### PR TITLE
Enhancement: Move common settings to a settings header and use clib.json instead of package.json in BEST PRACTICES

### DIFF
--- a/BEST_PRACTICE.md
+++ b/BEST_PRACTICE.md
@@ -4,9 +4,9 @@ This page will cover:
 
  - [How to use libraries](#how-to-use-installed-libraries-for-your-project).
  - [Example Makefile](#example-makefile).
- - [Example `package.json` for executables](#example-packagejson-for-executable-project).
+ - [Example `clib.json` for executables](#example-clibjson-for-executable-project).
  - [Making your own library package](#making-your-own-libraries).
- - [Example `package.json` for libraries](#example-packagejson-for-libraries).
+ - [Example `clib.json` for libraries](#example-clibjson-for-libraries).
  - [How to install/uninstall executables](#install-and-uninstall-executables-packages).
 
 For instructions on installation, check out the [README](https://github.com/clibs/clib#installation).
@@ -22,17 +22,17 @@ your-project/
 │   ├── trim.c/
 │   │   ├── trim.h
 │   │   ├── trim.c
-│   │   └── package.json
+│   │   └── clib.json
 │   │
 │   ├── commander/
 │   │   ├─ commander.h
 │   │   ├─ commander.c
-│   │   └─ package.json
+│   │   └─ clib.json
 │   │
 │   └── logger/
 │       ├── logger.h
 │       ├── logger.c
-│       └── package.json
+│       └── clib.json
 │
 ├── LICENSE
 │
@@ -40,7 +40,7 @@ your-project/
 │
 ├── README.md
 │
-├── package.json
+├── clib.json
 │
 └── src/
     ├── main.c
@@ -102,11 +102,11 @@ This is a basic Makefile, and should work for most of your projects.
 You *could* have your Makefile install the libraries upon running it, but you
 would only need to do that to get the latest version of the library(s), in this
 case you probably don't want that. You typically want yo get the latest stable version
-for that library. By having a `package.json` file in your project repo, you can
+for that library. By having a `clib.json` file in your project repo, you can
 specify what packages you need, and what version of that package. Now have a look
-at a example `package.json` file for your project: (executable package)
+at a example `clib.json` file for your project: (executable package)
 
-### Example package.json for executable project
+### Example clib.json for executable project
 
 ```json
 {
@@ -125,7 +125,7 @@ at a example `package.json` file for your project: (executable package)
 
 Starting from the top, `"name"` is your package name. `"version"` is your package version. `"repo"` is the location of your project, (not including the `https://github.com/`). `"dependencies"` is all the dependencies your project requires, along with there version. `"install"` is the command to install your program (ran as root), (tip: if your project requires more then one command to install it, like need to run `./configure`, before `make`, then do this: `"install": "./configure && make && make install"`). `"uninstall"` is the command to uninstall your project, [more on that later](#install-and-uninstall-executables).
  
-_**NOTE:** Make sure you have a release as the same version in your `package.json` file, otherwise the download will fail. If you always want your package at the latest version, then put `master` as your version._
+_**NOTE:** Make sure you have a release as the same version in your `clib.json` file, otherwise the download will fail. If you always want your package at the latest version, then put `master` as your version._
 
 ## Making your own libraries
 
@@ -140,12 +140,12 @@ your-library-c/
 │   ├── path-join.c/
 │   │   ├── path-join.h
 │   │   ├── path-join.c
-│   │   └── package.json
+│   │   └── clib.json
 │   │
 │   └── strdup/
 │       ├─ strdup.h
 │       ├─ strdup.c
-│       └─ package.json
+│       └─ clib.json
 │
 ├── LICENSE
 │
@@ -153,7 +153,7 @@ your-library-c/
 │
 ├── README.md
 │
-├── package.json
+├── clib.json
 │
 ├── src/
 │   ├── library.c
@@ -165,11 +165,11 @@ your-library-c/
 
 Also like before, your have a `deps` directory (depending on your library, you may not need any
 dependencies). Your `Makefile` in this case it is only for the `test.sh`, not needed for installing.
-`package.json` contains your library name, dependencies (if you need them), keywords, etc... In
+`clib.json` contains your library name, dependencies (if you need them), keywords, etc... In
 `src/` contains your make code (usally the same name as your library). And you have your `test.sh`
 used for testing.
 
-### Example package.json for libraries
+### Example clib.json for libraries
 
 ```
 {
@@ -194,14 +194,14 @@ used for testing.
 }
 ```
 
-The main differences (between this, and the executable `package.json`), is now there is `"src"`,
+The main differences (between this, and the executable `clib.json`), is now there is `"src"`,
 this is where your make library source code is, your can change it, but src is petty standard.
 
 **TIP:** In the `"dependencies"` section, if you define `"*"` as the version, clib will install
 the latest version of that library.
 
 _**NOTE:** Just like your executable package, you will want to tag a release with the same name
-as your version specified in your `package.json`._
+as your version specified in your `clib.json`._
 
 ## Install and uninstall executables packages
 

--- a/src/clib-build.c
+++ b/src/clib-build.c
@@ -5,6 +5,7 @@
 // MIT licensed
 //
 
+#include "common/clib-settings.h"
 #include <curl/curl.h>
 #include <errno.h>
 #include <libgen.h>
@@ -43,15 +44,10 @@
 
 #include "version.h"
 
-#define CLIB_PACKAGE_CACHE_TIME 30 * 24 * 60 * 60
 #define PROGRAM_NAME "clib-build"
 
 #define SX(s) #s
 #define S(s) SX(s)
-
-#ifdef HAVE_PTHREADS
-#define MAX_THREADS 4
-#endif
 
 #ifndef DEFAULT_MAKE_CLEAN_TARGET
 #define DEFAULT_MAKE_CLEAN_TARGET "clean"
@@ -82,8 +78,6 @@ struct options {
   unsigned int concurrency;
 #endif
 };
-
-const char *manifest_names[] = {"clib.json", "package.json", 0};
 
 clib_package_opts_t package_opts = {0};
 clib_package_t *root_package = 0;

--- a/src/clib-configure.c
+++ b/src/clib-configure.c
@@ -29,6 +29,7 @@
 
 #include "common/clib-cache.h"
 #include "common/clib-package.h"
+#include "common/clib-settings.h"
 
 #include <asprintf/asprintf.h>
 #include <commander/commander.h>
@@ -43,15 +44,10 @@
 
 #include "version.h"
 
-#define CLIB_PACKAGE_CACHE_TIME 30 * 24 * 60 * 60
 #define PROGRAM_NAME "clib-configure"
 
 #define SX(s) #s
 #define S(s) SX(s)
-
-#ifdef HAVE_PTHREADS
-#define MAX_THREADS 4
-#endif
 
 #if defined(_WIN32) || defined(WIN32) || defined(__MINGW32__) ||               \
     defined(__MINGW64__)
@@ -73,8 +69,6 @@ struct options {
   unsigned int concurrency;
 #endif
 };
-
-const char *manifest_names[] = {"clib.json", "package.json", 0};
 
 clib_package_opts_t package_opts = {0};
 clib_package_t *root_package = 0;

--- a/src/clib-install.c
+++ b/src/clib-install.c
@@ -8,6 +8,7 @@
 #include "commander/commander.h"
 #include "common/clib-cache.h"
 #include "common/clib-package.h"
+#include "common/clib-settings.h"
 #include "common/clib-validate.h"
 #include "debug/debug.h"
 #include "fs/fs.h"
@@ -23,14 +24,8 @@
 #include <stdlib.h>
 #include <string.h>
 
-#define CLIB_PACKAGE_CACHE_TIME 30 * 24 * 60 * 60
-
 #define SX(s) #s
 #define S(s) SX(s)
-
-#ifdef HAVE_PTHREADS
-#define MAX_THREADS 12
-#endif
 
 #if defined(_WIN32) || defined(WIN32) || defined(__MINGW32__) ||               \
     defined(__MINGW64__)
@@ -59,8 +54,6 @@ struct options {
 };
 
 static struct options opts = {0};
-
-static const char *manifest_names[] = {"clib.json", "package.json", NULL};
 
 static clib_package_opts_t package_opts = {0};
 static clib_package_t *root_package = NULL;

--- a/src/clib-search.c
+++ b/src/clib-search.c
@@ -10,6 +10,7 @@
 #include "commander/commander.h"
 #include "common/clib-cache.h"
 #include "common/clib-package.h"
+#include "common/clib-settings.h"
 #include "console-colors/console-colors.h"
 #include "debug/debug.h"
 #include "fs/fs.h"
@@ -26,7 +27,6 @@
 #include <time.h>
 
 #define CLIB_WIKI_URL "https://github.com/clibs/clib/wiki/Packages"
-#define CLIB_SEARCH_CACHE_TIME 1 * 24 * 60 * 60
 
 #if defined(_WIN32) || defined(WIN32) || defined(__MINGW32__) ||               \
     defined(__MINGW64__)

--- a/src/clib-uninstall.c
+++ b/src/clib-uninstall.c
@@ -9,6 +9,7 @@
 
 #include "asprintf/asprintf.h"
 #include "commander/commander.h"
+#include "common/clib-settings.h"
 #include "debug/debug.h"
 #include "fs/fs.h"
 #include "http-get/http-get.h"
@@ -25,8 +26,6 @@
     defined(__MINGW64__)
 #define setenv(k, v, _) _putenv_s(k, v)
 #endif
-
-const char *manifest_names[] = {"clib.json", "package.json", NULL};
 
 debug_t debugger;
 

--- a/src/clib-update.c
+++ b/src/clib-update.c
@@ -8,6 +8,7 @@
 #include "commander/commander.h"
 #include "common/clib-cache.h"
 #include "common/clib-package.h"
+#include "common/clib-settings.h"
 #include "common/clib-validate.h"
 #include "debug/debug.h"
 #include "fs/fs.h"
@@ -23,14 +24,8 @@
 #include <stdlib.h>
 #include <string.h>
 
-#define CLIB_PACKAGE_CACHE_TIME 30 * 24 * 60 * 60
-
 #define SX(s) #s
 #define S(s) SX(s)
-
-#ifdef HAVE_PTHREADS
-#define MAX_THREADS 12
-#endif
 
 #if defined(_WIN32) || defined(WIN32) || defined(__MINGW32__) ||               \
     defined(__MINGW64__)
@@ -54,8 +49,6 @@ struct options {
 };
 
 static struct options opts = {0};
-
-static const char *manifest_names[] = {"clib.json", "package.json", NULL};
 
 static clib_package_opts_t package_opts = {0};
 static clib_package_t *root_package = NULL;

--- a/src/clib-upgrade.c
+++ b/src/clib-upgrade.c
@@ -9,6 +9,7 @@
 #include "common/clib-cache.h"
 #include "common/clib-package.h"
 #include "common/clib-release-info.h"
+#include "common/clib-settings.h"
 #include "debug/debug.h"
 #include "fs/fs.h"
 #include "http-get/http-get.h"
@@ -25,14 +26,8 @@
 #include <stdlib.h>
 #include <string.h>
 
-#define CLIB_PACKAGE_CACHE_TIME 30 * 24 * 60 * 60
-
 #define SX(s) #s
 #define S(s) SX(s)
-
-#ifdef HAVE_PTHREADS
-#define MAX_THREADS 16
-#endif
 
 #if defined(_WIN32) || defined(WIN32) || defined(__MINGW32__) ||               \
     defined(__MINGW64__)
@@ -58,8 +53,6 @@ struct options {
 };
 
 static struct options opts = {0};
-
-static const char *manifest_names[] = {"clib.json", "package.json", NULL};
 
 static clib_package_opts_t package_opts = {0};
 static clib_package_t *root_package = NULL;

--- a/src/common/clib-package.c
+++ b/src/common/clib-package.c
@@ -12,6 +12,7 @@
 #include "asprintf/asprintf.h"
 #include "clib-cache.h"
 #include "clib-package.h"
+#include "clib-settings.h"
 #include "debug/debug.h"
 #include "fs/fs.h"
 #include "hash/hash.h"
@@ -86,8 +87,6 @@ debug_t _debugger;
     debug(&_debugger, __VA_ARGS__);                                            \
   })
 
-static const char *manifest_names[] = {"clib.json", "package.json", NULL};
-
 #define E_FORMAT(...)                                                          \
   ({                                                                           \
     rc = asprintf(__VA_ARGS__);                                                \
@@ -97,7 +96,7 @@ static const char *manifest_names[] = {"clib.json", "package.json", NULL};
 
 static clib_package_opts_t opts = {
 #ifdef HAVE_PTHREADS
-    .concurrency = 4,
+    .concurrency = MAX_THREADS,
 #endif
     .skip_cache = 1,
     .prefix = 0,

--- a/src/common/clib-settings.h
+++ b/src/common/clib-settings.h
@@ -1,0 +1,14 @@
+#ifndef CLIB_SETTINGS_H
+#define CLIB_SETTINGS_H
+
+// Shared settings
+#define CLIB_PACKAGE_CACHE_TIME 30 * 24 * 60 * 60
+#define CLIB_SEARCH_CACHE_TIME 1 * 24 * 60 * 60
+
+#ifdef HAVE_PTHREADS
+#define MAX_THREADS 12
+#endif
+
+const char *manifest_names[] = {"clib.json", "package.json", 0};
+
+#endif // CLIB_SRC_COMMON_CLIB_SETTINGS_H


### PR DESCRIPTION
I think that it is more clear to define the thread count, cache time and manifest names in one place.