### PR TITLE
bugfix for compile_settings

### DIFF
--- a/src/clib-build.c
+++ b/src/clib-build.c
@@ -469,7 +469,6 @@ cleanup:
 }
 
 int build_package(const char *dir) {
-  static const char *manifest_names[] = {"clib.json", "package.json", 0};
   const char *name = NULL;
   unsigned int i = 0;
   int rc = 0;

--- a/src/common/clib-settings.c
+++ b/src/common/clib-settings.c
@@ -1,0 +1,3 @@
+#include "clib-settings.h"
+
+const char *manifest_names[] = {"clib.json", "package.json", 0};

--- a/src/common/clib-settings.h
+++ b/src/common/clib-settings.h
@@ -9,6 +9,6 @@
 #define MAX_THREADS 12
 #endif
 
-const char *manifest_names[] = {"clib.json", "package.json", 0};
+extern const char *manifest_names[];
 
 #endif // CLIB_SRC_COMMON_CLIB_SETTINGS_H

--- a/test/package/Makefile
+++ b/test/package/Makefile
@@ -3,7 +3,7 @@ CC ?= cc
 VALGRIND ?= valgrind
 TEST_RUNNER ?=
 
-SRC = ../../src/common/clib-package.c ../../src/common/clib-cache.c ../../src/common/clib-release-info.c
+SRC = ../../src/common/clib-package.c ../../src/common/clib-cache.c ../../src/common/clib-release-info.c ../../src/common/clib-settings.c
 DEPS += $(wildcard ../../deps/*/*.c)
 OBJS = $(SRC:.c=.o) $(DEPS:.c=.o)
 TEST_SRC = $(wildcard *.c)


### PR DESCRIPTION
I forgot to make the manifest names static. Therefore the variable was exposed by every unit that included the compile_settings, which caused the multiple definition errors when linking.