### PR TITLE
Fixing the failing tests on MacOS

### DIFF
--- a/test/package/package-install-dependencies.c
+++ b/test/package/package-install-dependencies.c
@@ -1,5 +1,6 @@
 
 #include "clib-package.h"
+#include "clib-cache.h"
 #include "describe/describe.h"
 #include "fs/fs.h"
 #include "rimraf/rimraf.h"
@@ -11,6 +12,9 @@ int main() {
       .prefix = 0,
       .force = 1,
   });
+
+  clib_cache_init(100);
+  rimraf(clib_cache_dir());
 
   describe("clib_package_install_dependencies") {
     it("should return -1 when given a bad package") {

--- a/test/package/package-install-dev-dependencies.c
+++ b/test/package/package-install-dev-dependencies.c
@@ -1,5 +1,6 @@
 
 #include "clib-package.h"
+#include "clib-cache.h"
 #include "describe/describe.h"
 #include "fs/fs.h"
 #include "rimraf/rimraf.h"
@@ -11,6 +12,9 @@ int main() {
       .prefix = 0,
       .force = 1,
   });
+
+  clib_cache_init(100);
+  rimraf(clib_cache_dir());
 
   describe("clib_package_install_development") {
     it("should return -1 when given a bad package") {

--- a/test/package/package-install.c
+++ b/test/package/package-install.c
@@ -1,5 +1,5 @@
 
-#include "clib-package.h"
+#include "clib-cache.h"
 #include "describe/describe.h"
 #include "fs/fs.h"
 #include "rimraf/rimraf.h"
@@ -12,6 +12,9 @@ int main() {
       .prefix = 0,
       .force = 1,
   });
+
+  clib_cache_init(100);
+  rimraf(clib_cache_dir());
 
   describe("clib_package_install") {
     it("should return -1 when given a bad package") {

--- a/test/package/package-install.c
+++ b/test/package/package-install.c
@@ -1,4 +1,5 @@
 
+#include "clib-package.h"
 #include "clib-cache.h"
 #include "describe/describe.h"
 #include "fs/fs.h"


### PR DESCRIPTION
Looks like a possible source of these random failings, and wild seg faults is that the cache is not initialized in some tests where it's actually used. For some reason it causes some completely unrelated issues in the mac build. Probably the uninitialized variables corrupted the memory.