### PR TITLE
Only successful installs should be cached

### DIFF
--- a/src/common/clib-package.c
+++ b/src/common/clib-package.c
@@ -1555,13 +1555,6 @@ download:
   }
 #endif
 
-#ifdef HAVE_PTHREADS
-  pthread_mutex_lock(&lock.mutex);
-#endif
-  clib_cache_save_package(pkg->author, pkg->name, pkg->version, pkg_dir);
-#ifdef HAVE_PTHREADS
-  pthread_mutex_unlock(&lock.mutex);
-#endif
 
 install:
   if (pkg->configure) {
@@ -1581,6 +1574,16 @@ install:
   if (0 == rc) {
     rc = clib_package_install_dependencies(pkg, dir, verbose);
   }
+
+if (0 == rc) {
+#ifdef HAVE_PTHREADS
+  pthread_mutex_lock(&lock.mutex);
+#endif
+  clib_cache_save_package(pkg->author, pkg->name, pkg->version, pkg_dir);
+#ifdef HAVE_PTHREADS
+  pthread_mutex_unlock(&lock.mutex);
+#endif
+}
 
 cleanup:
   if (pkg_dir)


### PR DESCRIPTION
When a package cannot be fetched, then it shouldn't be cached. Reproduction:

- package.json in the repo https://github.com/h2non/semver.c is versioned to 1.0.0, but the actual tag is v1.0.0
- `clib install h2non/semver.c` will fail for the first time, but the source files will be cached only containing a `404: Not Found` string
- For the second time these invalid files will be installed

A package should be cached only if it could be fetched and installed successfully