### PR TITLE
#291: Save dependencies to clib manifest by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ install: $(BINS)
 uninstall:
 	$(foreach c, $(BINS), $(RM) $(PREFIX)/bin/$(c);)
 
-test:
+test: $(BINS)
 	@./test.sh
 
 # create a list of auto dependencies

--- a/test/install-binary-dependencies.sh
+++ b/test/install-binary-dependencies.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-clib install -c stephenmathieson/tabs-to-spaces@1.0.0 -P tmp > /dev/null || {
+clib install -c -N stephenmathieson/tabs-to-spaces@1.0.0 -P tmp > /dev/null || {
   echo >&2 "Failed to install stephenmathieson/tabs-to-spaces"
   exit 1
 }

--- a/test/install-brace-expansion.sh
+++ b/test/install-brace-expansion.sh
@@ -5,7 +5,7 @@ throw() {
   exit 1
 }
 
-clib install -c -o tmp stephenmathieson/trim.c stephenmathieson/case.c > /dev/null ||
+clib install -c -N -o tmp stephenmathieson/trim.c stephenmathieson/case.c > /dev/null ||
   throw "expecting successful exit code"
 
 [ -d ./tmp/case ] && [ -f ./tmp/case/package.json ] ||

--- a/test/install-multiple-clibs-libs.sh
+++ b/test/install-multiple-clibs-libs.sh
@@ -5,7 +5,7 @@ throw() {
   exit 1
 }
 
-clib install -c -o tmp ms file hash > /dev/null ||
+clib install -c -N -o tmp ms file hash > /dev/null ||
   throw "expecting successful exit code"
 
 [ -d ./tmp/ms ] && [ -f ./tmp/ms/package.json ] ||

--- a/test/install-multiple-libs.sh
+++ b/test/install-multiple-libs.sh
@@ -5,7 +5,7 @@ throw() {
   exit 1
 }
 
-clib install -c -o tmp \
+clib install -c -N -o tmp \
   stephenmathieson/case.c stephenmathieson/trim.c > /dev/null ||
   throw "expecting successful exit code"
 

--- a/test/install-no-save.sh
+++ b/test/install-no-save.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+mkdir -p tmp/test-save
+cp test/data/test-save-package.json tmp/test-save/package.json
+
+cd tmp/test-save || exit
+../../clib-install -c --no-save stephenmathieson/tabs-to-spaces@1.0.0 >/dev/null
+../../clib-install -c -N darthtrevino/str-concat@0.0.2 >/dev/null
+../../clib-install -c --dev --no-save jwerle/fs.c@0.1.1 >/dev/null
+../../clib-install -c -d --no-save clibs/parson@1.0.2 >/dev/null
+cd - || exit
+
+if grep --quiet "stephenmathieson/tabs-to-spaces" tmp/test-save/package.json; then
+  echo >&2 "Found stephenmathieson/tabs-to-spaces saved in package.json but --no-save was used"
+  exit 1
+fi
+
+if grep --quiet "darthtrevino/str-concat" tmp/test-save/package.json; then
+  echo >&2 "Found darthtrevino/strconcat saved in package.json but --no-save was used"
+  exit 1
+fi
+
+if grep --quiet "jwerle/fs.c" tmp/test-save/package.json; then
+  echo >&2 "Found jwerle/fs.c saved in package.json but --no-save was used"
+  exit 1
+fi
+
+if grep --quiet "clibs/parson" tmp/test-save/package.json; then
+  echo >&2 "Found clibs/parson saved in package.json but --no-save was used"
+  exit 1
+fi

--- a/test/install-save.sh
+++ b/test/install-save.sh
@@ -3,9 +3,9 @@ mkdir -p tmp/test-save
 cp test/data/test-save-package.json tmp/test-save/package.json
 
 cd tmp/test-save || exit
-../../clib-install -c --save stephenmathieson/tabs-to-spaces@1.0.0 >/dev/null
-../../clib-install -c -S darthtrevino/str-concat@0.0.2 >/dev/null
-../../clib-install -c --save-dev jwerle/fs.c@0.1.1 >/dev/null
+../../clib-install -c stephenmathieson/tabs-to-spaces@1.0.0 >/dev/null
+../../clib-install -c darthtrevino/str-concat@0.0.2 >/dev/null
+../../clib-install -c --dev jwerle/fs.c@0.1.1 >/dev/null
 ../../clib-install -c -D clibs/parson@1.0.2 >/dev/null
 cd - || exit
 

--- a/test/uninstall.sh
+++ b/test/uninstall.sh
@@ -2,7 +2,7 @@
 
 mkdir -p tmp/bin
 
-clib install -c stephenmathieson/tabs-to-spaces@1.0.0 -P tmp > /dev/null || {
+clib install -c -N stephenmathieson/tabs-to-spaces@1.0.0 -P tmp > /dev/null || {
   echo >&2 "Failed to install stephenmathieson/tabs-to-spaces"
   exit 1
 }


### PR DESCRIPTION
This PR modifies the behavior of `clib-install` such that dependencies are saved to the clib manifest (clib.json/package.json) by default, mirroring the behavior of npm >= 5. It accomplishes this by deprecating the `--save` option and adding an additional flag `--no-save` which can be passed to prevent the dependency from being written to the clib manifest. 

Note I've retained the `--save-dev` option so users can specify they want the dependency to save under dev dependencies. This is also aligned with the behavior of npm >= 5. 

Changes:
- Deprecate `--save` option and add a logger warning. Behavior when this flag is passed is effectively the same to prevent backward compatibility issues.
- Add new `--no-save` flag, which changes the install behavior such that the dependency is not added to the clib manifest.
- In an additional commit, I added the `make` target for the binaries as a dependency of the `test` target. I noticed that if you run `make test` without having run `make` first, the tests will fail. 
- Added new test cases for `--no-save`. Also updated existing test cases where necessary with `--no-save` just to maintain parity with what was there before. We could probably refactor the `--save` and `--no-save` tests to use a common function, but I wanted to keep the PR small, and having separate test files lets us fine-tune the behavior for one without clobbering the other.

Resolves #291. 
---
When we're good, I can push a tag to bump the version or however you prefer. Happy to make any suggested changes.