### PR TITLE
fix: Do not discard `const` type qualifier

### DIFF
--- a/src/clib-install.c
+++ b/src/clib-install.c
@@ -399,7 +399,7 @@ int main(int argc, char *argv[]) {
   }
 
   if (!root_package) {
-    char *name = NULL;
+    const char *name = NULL;
     char *json = NULL;
     unsigned int i = 0;
 

--- a/src/clib-update.c
+++ b/src/clib-update.c
@@ -317,7 +317,7 @@ int main(int argc, char *argv[]) {
   }
 
   if (!root_package) {
-    char *name = NULL;
+    const char *name = NULL;
     char *json = NULL;
     unsigned int i = 0;
 


### PR DESCRIPTION
In the changed code, `name` is assigned a pointer, that was some offset value from `manifest_names`.

`manifest_names` is defined like so:

```c
extern const char *manifest_names[];
```

In all cases, `name` is being passed into the `fs_read` function, which has the following declaration:

```c
char *fs_read (const char *path);
```

Because the "source" and "destination" of `name` has a type of `const char *`, changing `name` to match that improves consistensy. This also fixes a `-Wdiscarded-qualifiers` warning that may show upon compilation.