### PR TITLE
Fix failing tests, cleanup issues w/running tests locally

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -1,7 +1,13 @@
 #!/bin/sh
 
-mkdir -p tmp/bin
-TESTS=$(find test/* -type f -perm -111)
+ctrl_c () {
+  echo "Ctrl+c detected. Exiting..."
+  exit 1
+}
+
+trap ctrl_c INT
+
+TESTS=$(find test/*.sh -type f -perm -111)
 EXIT_CODE=0
 export PATH="$PWD:$PATH"
 
@@ -17,21 +23,20 @@ for t in $TESTS; do
 done
 echo
 
-
 printf "\nRunning clib package tests\n\n"
 cd test/package && make clean
 
 if ! make test; then
-    EXIT_CODE=1
+  EXIT_CODE=1
 fi
 
 cd ../../
 
 printf "\nRunning clib cache tests\n\n"
-cd test/cache 
+cd test/cache && make clean
 
 if ! make test; then
-    EXIT_CODE=1
+  EXIT_CODE=1
 fi
 
 cd ../../

--- a/test/install-binary-dependencies.sh
+++ b/test/install-binary-dependencies.sh
@@ -1,9 +1,13 @@
 #!/bin/sh
 
+mkdir -p tmp/bin
+trap 'rm -rf tmp' EXIT
+
 clib install -c -N stephenmathieson/tabs-to-spaces@1.0.0 -P tmp > /dev/null || {
   echo >&2 "Failed to install stephenmathieson/tabs-to-spaces"
   exit 1
 }
+
 command -v tmp/bin/t2s >/dev/null 2>&1 || {
   echo >&2 "Failed to put t2s on path"
   exit 1

--- a/test/install-brace-expansion.sh
+++ b/test/install-brace-expansion.sh
@@ -5,6 +5,8 @@ throw() {
   exit 1
 }
 
+trap 'rm -rf tmp' EXIT
+
 clib install -c -N -o tmp stephenmathieson/trim.c stephenmathieson/case.c > /dev/null ||
   throw "expecting successful exit code"
 
@@ -13,5 +15,3 @@ clib install -c -N -o tmp stephenmathieson/trim.c stephenmathieson/case.c > /dev
 
 [ -d ./tmp/trim ] && [ -f ./tmp/trim/package.json ] ||
   throw "failed to install trim.c"
-
-rm -rf ./tmp

--- a/test/install-deps-from-package-json.sh
+++ b/test/install-deps-from-package-json.sh
@@ -5,8 +5,9 @@ throw() {
   exit 1
 }
 
-rm -rf tmp
 mkdir -p tmp
+trap 'rm -rf tmp' EXIT
+
 cd tmp || exit
 
 # see https://github.com/clibs/clib/issues/45
@@ -25,4 +26,3 @@ clib install > /dev/null 2>&1
 [ $? -eq 1 ] || throw "expecting exit code of 1";
 
 cd - > /dev/null || exit
-rm -rf ./tmp

--- a/test/install-multiple-clibs-libs.sh
+++ b/test/install-multiple-clibs-libs.sh
@@ -5,6 +5,8 @@ throw() {
   exit 1
 }
 
+trap 'rm -rf tmp' EXIT
+
 clib install -c -N -o tmp ms file hash > /dev/null ||
   throw "expecting successful exit code"
 
@@ -16,5 +18,3 @@ clib install -c -N -o tmp ms file hash > /dev/null ||
 
 [ -d ./tmp/hash ] && [ -f ./tmp/hash/package.json ] ||
   throw "failed to install hash"
-
-rm -rf ./tmp

--- a/test/install-multiple-libs.sh
+++ b/test/install-multiple-libs.sh
@@ -5,6 +5,8 @@ throw() {
   exit 1
 }
 
+trap 'rm -rf tmp' EXIT
+
 clib install -c -N -o tmp \
   stephenmathieson/case.c stephenmathieson/trim.c > /dev/null ||
   throw "expecting successful exit code"
@@ -14,5 +16,3 @@ clib install -c -N -o tmp \
 
 [ -d ./tmp/trim ] && [ -f ./tmp/trim/package.json ] ||
   throw "failed to install trim.c"
-
-rm -rf ./tmp

--- a/test/install-no-save.sh
+++ b/test/install-no-save.sh
@@ -1,9 +1,12 @@
 #!/bin/sh
-mkdir -p tmp/test-save
+mkdir -p tmp/test-save/bin
+RUNDIR="$PWD"
+trap 'rm -rf "$RUNDIR/tmp"' EXIT
+
 cp test/data/test-save-package.json tmp/test-save/package.json
 
 cd tmp/test-save || exit
-../../clib-install -c --no-save stephenmathieson/tabs-to-spaces@1.0.0 >/dev/null
+../../clib-install -c --no-save stephenmathieson/tabs-to-spaces@1.0.0 -P . >/dev/null
 ../../clib-install -c -N darthtrevino/str-concat@0.0.2 >/dev/null
 ../../clib-install -c --dev --no-save jwerle/fs.c@0.1.1 >/dev/null
 ../../clib-install -c -d --no-save clibs/parson@1.0.2 >/dev/null

--- a/test/install-save.sh
+++ b/test/install-save.sh
@@ -1,9 +1,12 @@
 #!/bin/sh
-mkdir -p tmp/test-save
+mkdir -p tmp/test-save/bin
+RUNDIR="$PWD"
+trap 'rm -rf "$RUNDIR/tmp"' EXIT
+
 cp test/data/test-save-package.json tmp/test-save/package.json
 
 cd tmp/test-save || exit
-../../clib-install -c stephenmathieson/tabs-to-spaces@1.0.0 >/dev/null
+../../clib-install -c stephenmathieson/tabs-to-spaces@1.0.0 -P . >/dev/null
 ../../clib-install -c darthtrevino/str-concat@0.0.2 >/dev/null
 ../../clib-install -c --dev jwerle/fs.c@0.1.1 >/dev/null
 ../../clib-install -c -D clibs/parson@1.0.2 >/dev/null

--- a/test/uninstall.sh
+++ b/test/uninstall.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-
 mkdir -p tmp/bin
+trap 'rm -rf tmp' EXIT
 
 clib install -c -N stephenmathieson/tabs-to-spaces@1.0.0 -P tmp > /dev/null || {
   echo >&2 "Failed to install stephenmathieson/tabs-to-spaces"


### PR DESCRIPTION
This PR fixes some of the issues in [this ci failure](https://github.com/clibs/clib/actions/runs/6804237760/job/18501316937#step:6:1507) and false negatives when running tests locally (e.g. due to inadvertently running the cache tests twice). 

Changes:
- Use traps to cleanup test artifacts (in case a test fails, we don't leave the artifacts to potentially cause false negatives in the next test).
- Allow ctrl+c to fast-exit from test script 
- Ensure all binary installs in tests set the prefix opt (avoids perms issues in some systems)
- Fix test script such that cache tests only run once

Thanks 

@jwerle @stephenmathieson 