### PR TITLE
fix(makefile): Add missing dependencies from `src/common/*`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ all: $(BINS)
 
 build: $(BINS)
 
-$(BINS): $(SRC) $(MAKEFILES) $(OBJS)
+$(BINS): $(SRC) $(COMMON_SRC) $(MAKEFILES) $(OBJS)
 	$(CC) $(CFLAGS) -o $@ $(COMMON_SRC) src/$(@:.exe=).c $(OBJS) $(LDFLAGS)
 
 $(MAKEFILES):


### PR DESCRIPTION
As noted in the issue, when files like `src/common/clib-cache.c` were modified, running `make` did not rebuild `clib`. Now, it does.

Closes #298
Closes #284
Closes #276