### PR TITLE
Additional check for pthread_cancel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ endif
 
 ifneq (0,$(PTHREADS))
 ifndef NO_PTHREADS
-	CFLAGS += $(shell ./scripts/feature-test-pthreads && echo "-DHAVE_PTHREADS=1 -pthread" || echo "-DHAVE_PTHREADS=0")
+	CFLAGS += $(shell ./scripts/feature-test-pthreads && echo "-DHAVE_PTHREADS=1 -pthread")
 endif
 endif
 

--- a/scripts/feature-test-pthreads
+++ b/scripts/feature-test-pthreads
@@ -3,6 +3,6 @@
 {
   echo '#include <pthread.h>' &&
   echo 'void *f(void *a) { return 0; }' &&
-  echo 'int main(void) { pthread_t t; return pthread_create(&t, 0, f, 0); }';
+  echo 'int main(void) { pthread_t t; int ret = pthread_create(&t, 0, f, 0); ret |= pthread_cancel(t); return ret; }';
 } | ${CC:-cc} -o pthread_test -xc -pthread - 2>/dev/null && rm pthread_test
 exit $?


### PR DESCRIPTION
Some platforms (android, really) do not implement `pthread_cancel` and a few other functions, so this PR
adds a check for such cases.
Besides that, `HAVE_PTHREADS` must not be defined at all when pthread is not available.

Related: #304 