### PR TITLE
Fix double free in clib-package

### DIFF
--- a/src/common/clib-package.c
+++ b/src/common/clib-package.c
@@ -704,22 +704,20 @@ clib_package_new_from_slug_with_package_name(const char *slug, int verbose,
 
   // force version number
   if (pkg->version) {
-    if (version) {
-      if (0 != strcmp(version, DEFAULT_REPO_VERSION)) {
-        _debug("forcing version number: %s (%s)", version, pkg->version);
-        free(pkg->version);
-        pkg->version = version;
-      } else {
-        free(version);
-        version = NULL;
-      }
+    if (0 != strcmp(version, DEFAULT_REPO_VERSION)) {
+      _debug("forcing version number: %s (%s)", version, pkg->version);
+      free(pkg->version);
+      pkg->version = version;
+    } else {
+      free(version);
+      version = NULL;
     }
   } else {
     pkg->version = version;
   }
 
   // force package author (don't know how this could fail)
-  if (author && pkg->author) {
+  if (pkg->author) {
     if (0 != strcmp(author, pkg->author)) {
       free(pkg->author);
       pkg->author = author;


### PR DESCRIPTION
This PR fixes two double frees in `clib_package_new_from_slug_with_package_name()`, which were
found and reported by @HoshinoStranding (thank you!)
It appears that git has run a code-formatting pre-commit hook on the first commit, making it
a little messy, but at it's core we simply assign NULL to just-freed variables so that we don't try to
free them again. I also removed a few unnecessary nullability checks, since the initial ones are
done right after calling the corresponding parse functions and are more than enough.
Fixes: #307 #308 