### PR TITLE
Update fuzz_manifest.c: Add missing include unistd.h

### DIFF
--- a/test/fuzzing/fuzz_manifest.c
+++ b/test/fuzzing/fuzz_manifest.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdint.h>
+#include <unistd.h>
 #include "../../src/common/clib-package.h"
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {


### PR DESCRIPTION
To fix a clang-18 error:

```
test/fuzzing/fuzz_manifest.c:25:5: error: call to undeclared function 'unlink'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
   25 |     unlink(filename);
      |     ^
1 error generated.
ERROR:__main__:Building fuzzers failed.
