### PR TITLE
Add installation instruction for Fedora

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -45,6 +45,20 @@ $ make
 $ sudo make install
 ```
 
+  Fedora:
+
+```sh
+# install libcurl
+$ sudo dnf install libcurl-devel
+# clone
+$ git clone https://github.com/clibs/clib.git /tmp/clib && cd /tmp/clib
+# build
+$ make
+# put on path
+$ sudo make install
+```
+
+
 ## About
 
   Basically the lazy-man's copy/paste promoting smaller C utilities, also


### PR DESCRIPTION
**It really took me a long time to find out how to install `libcurl`** when I was trying to install Clib on Fedora Linux.
How about adding the installation instruction for Fedora to `Readme.md`?