### PR TITLE
Fix memory leak in clib_package_new

### DIFF
--- a/src/common/clib-package.c
+++ b/src/common/clib-package.c
@@ -513,6 +513,8 @@ clib_package_t *clib_package_new(const char *json, int verbose) {
       for (unsigned int i = 0; i < json_array_get_count(flags); i++) {
         char *flag = json_array_get_string_safe(flags, i);
         if (flag) {
+          char *old_flags = pkg->flags;
+
           if (!pkg->flags) {
             pkg->flags = "";
           }
@@ -521,6 +523,7 @@ clib_package_t *clib_package_new(const char *json, int verbose) {
             goto cleanup;
           }
 
+          free(old_flags);
           free(flag);
         }
       }


### PR DESCRIPTION
The leak was found by fuzzer:

```
=================================================================
==335809==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 32 byte(s) in 1 object(s) allocated from:
    #0 0x55f752b5da5e in malloc (clib/myfuzzing/prefix/bin/fuzz_manifest+0x117a5e)
    #1 0x55f752bbfa4a in json_object_init clib/deps/parson/parson.c:291:42
    #2 0x55f752bbf8e9 in json_value_init_object clib/deps/parson/parson.c:1077:31
    #3 0x55f752bc839f in parse_object_value clib/deps/parson/parson.c:580:32
    #4 0x55f752bbd0e4 in parse_value clib/deps/parson/parson.c:561:20
    #5 0x55f752bc8a6e in parse_object_value clib/deps/parson/parson.c:600:21
    #6 0x55f752bbd0e4 in parse_value clib/deps/parson/parson.c:561:20
    #7 0x55f752bbc55a in json_parse_string clib/deps/parson/parson.c:910:12
    #8 0x55f752ba5b01 in clib_package_new clib/src/common/clib-package.c:468:16
    #9 0x55f752ba58b2 in clib_package_load_from_manifest clib/src/common/clib-package.c:259:9
    #10 0x55f752b9c9fa in LLVMFuzzerTestOneInput clib/test/fuzzing/fuzz_manifest.c:22:6
    #11 0x55f752aa8a70 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (clib/myfuzzing/prefix/bin/fuzz_manifest+0x62a70)
    #12 0x55f752aa81e5 in fuzzer::Fuzzer::RunOne(unsigned char const*, unsigned long, bool, fuzzer::InputInfo*, bool, bool*) (clib/myfuzzing/prefix/bin/fuzz_manifest+0x621e5)
    #13 0x55f752aa99c5 in fuzzer::Fuzzer::MutateAndTestOne() (clib/myfuzzing/prefix/bin/fuzz_manifest+0x639c5)
    #14 0x55f752aaa5d5 in fuzzer::Fuzzer::Loop(std::vector<fuzzer::SizedFile, std::allocator<fuzzer::SizedFile>>&) (clib/myfuzzing/prefix/bin/fuzz_manifest+0x645d5)
    #15 0x55f752a9873b in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (clib/myfuzzing/prefix/bin/fuzz_manifest+0x5273b)
    #16 0x55f752ac1772 in main (clib/myfuzzing/prefix/bin/fuzz_manifest+0x7b772)
    #17 0x7fe6cea2fd8f in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16

SUMMARY: AddressSanitizer: 32 byte(s) leaked in 1 allocation(s).
```