### PR TITLE
Fix possible memory leak

### DIFF
--- a/src/clib-uninstall.c
+++ b/src/clib-uninstall.c
@@ -128,7 +128,7 @@ static char *get_uninstall_target(const char *name, const char *version) {
 
   size = asprintf(&target, "cd %s && %s", dir, val);
   if (-1 == size)
-    return NULL;
+    target = NULL;
 
 done:
   if (root)


### PR DESCRIPTION
The execution of ```return``` on line 131  leads to memory leaks because cleanup code at the end of the function is not called in this case.
Therefore, I removed ```return``` to avoid memory leaks.
