### PR TITLE
fix(clib-install): check if version was specified when installing.

### DIFF
--- a/src/clib-install.c
+++ b/src/clib-install.c
@@ -306,7 +306,15 @@ static int install_package(const char *slug) {
   }
 
   if (0 == pkg->repo || 0 != strcmp(slug, pkg->repo)) {
-    pkg->repo = strdup(slug);
+    char* version_char = NULL;
+    // NOTE: check if version was specified
+    if ((version_char = strchr(slug, '@')) != NULL) {
+      size_t length = version_char - slug;
+      pkg->repo = malloc(sizeof(char) * length);
+      memcpy(pkg->repo, slug, length);
+    } else {
+      pkg->repo = strdup(slug);
+    }
   }
 
   if (!opts.nosave) {


### PR DESCRIPTION
the names was used when writing the dependencies which causes this

$ clib install package@0.1.0

is written on json as

"package@0.1.0": "0.1.0"


Closes #330 